### PR TITLE
Modernize CI/CD workflow

### DIFF
--- a/.github/workflows/build-test-create-nuget-package.yml
+++ b/.github/workflows/build-test-create-nuget-package.yml
@@ -11,7 +11,7 @@ on:
 env:
   SOLUTION_PATH: 'AGDevX.sln'
   CONFIGURATION: 'Release'
-  PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}\output
+  PACKAGE_OUTPUT_DIRECTORY: ${{ github.workspace }}/output
   NUGET_API_URL: https://api.nuget.org/v3/index.json
 
 jobs:
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore dependencies
         run: dotnet restore ${{ env.SOLUTION_PATH }}


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v3 to v4
- Upgrade `actions/setup-dotnet` from v3 to v4
- Update `dotnet-version` from `7.0.x` to `10.0.x`
- Fix `PACKAGE_OUTPUT_DIRECTORY` to use forward slashes for cross-platform compatibility

## Why
GitHub Actions v3 runners are being deprecated. The workflow also referenced the EOL .NET 7 SDK and used Windows-only backslash path separators.

## Test plan
- [x] Workflow YAML is valid
- [x] Changes are limited to CI/CD configuration