### PR TITLE
Add NullIfNullOrWhiteSpace string extension

### DIFF
--- a/AGDevX.Tests/Strings/StringExtensionsTests.cs
+++ b/AGDevX.Tests/Strings/StringExtensionsTests.cs
@@ -140,13 +140,13 @@ public class StringExtensionsTests
         [Theory]
         [InlineData(null)]
         [InlineData("   ")]
-        public void And_the_string_is_null_or_whitespace_then_return_true(string str1)
+        public void And_the_string_is_null_or_whitespace_then_return_true(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNullOrWhiteSpace();
+            var result = str.IsNullOrWhiteSpace();
 
             //-- Assert
             Assert.True(result);
@@ -154,13 +154,13 @@ public class StringExtensionsTests
 
         [Theory]
         [InlineData("something")]
-        public void And_the_string_is_not_null_or_whitespace_then_return_false(string str1)
+        public void And_the_string_is_not_null_or_whitespace_then_return_false(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNullOrWhiteSpace();
+            var result = str.IsNullOrWhiteSpace();
 
             //-- Assert
             Assert.False(result);
@@ -171,13 +171,13 @@ public class StringExtensionsTests
     {
         [Theory]
         [InlineData("something")]
-        public void And_the_string_is_not_null_or_whitespace_then_return_true(string str1)
+        public void And_the_string_is_not_null_or_whitespace_then_return_true(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNotNullNorWhiteSpace();
+            var result = str.IsNotNullNorWhiteSpace();
 
             //-- Assert
             Assert.True(result);
@@ -186,13 +186,13 @@ public class StringExtensionsTests
         [Theory]
         [InlineData(null)]
         [InlineData("   ")]
-        public void And_the_string_null_or_whitespace_then_return_false(string str1)
+        public void And_the_string_null_or_whitespace_then_return_false(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNotNullNorWhiteSpace();
+            var result = str.IsNotNullNorWhiteSpace();
 
             //-- Assert
             Assert.False(result);
@@ -204,13 +204,13 @@ public class StringExtensionsTests
         [Theory]
         [InlineData(" ")]
         [InlineData("        ")]
-        public void And_the_string_is_whitespace_then_return_true(string str1)
+        public void And_the_string_is_whitespace_then_return_true(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsWhiteSpace();
+            var result = str.IsWhiteSpace();
 
             //-- Assert
             Assert.True(result);
@@ -223,13 +223,13 @@ public class StringExtensionsTests
         [InlineData("c ")]
         [InlineData(" d ")]
         [InlineData(" . ")]
-        public void And_the_string_is_not_whitespace_then_return_false(string str1)
+        public void And_the_string_is_not_whitespace_then_return_false(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsWhiteSpace();
+            var result = str.IsWhiteSpace();
 
             //-- Assert
             Assert.False(result);
@@ -245,13 +245,13 @@ public class StringExtensionsTests
         [InlineData("c ")]
         [InlineData(" d ")]
         [InlineData(" . ")]
-        public void And_the_string_is_null_or_not_whitespace_then_return_true(string str1)
+        public void And_the_string_is_null_or_not_whitespace_then_return_true(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNotWhiteSpace();
+            var result = str.IsNotWhiteSpace();
 
             //-- Assert
             Assert.True(result);
@@ -260,13 +260,13 @@ public class StringExtensionsTests
         [Theory]
         [InlineData(" ")]
         [InlineData("        ")]
-        public void And_the_string_is_whitespace_only_then_return_false(string str1)
+        public void And_the_string_is_whitespace_only_then_return_false(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNotWhiteSpace();
+            var result = str.IsNotWhiteSpace();
 
             //-- Assert
             Assert.False(result);
@@ -277,13 +277,13 @@ public class StringExtensionsTests
     {
         [Theory]
         [InlineData("")]
-        public void And_the_string_is_empty_only_then_return_true(string str1)
+        public void And_the_string_is_empty_only_then_return_true(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsEmpty();
+            var result = str.IsEmpty();
 
             //-- Assert
             Assert.True(result);
@@ -298,13 +298,13 @@ public class StringExtensionsTests
         [InlineData(" . ")]
         [InlineData(" ")]
         [InlineData("      ")]
-        public void And_the_string_is_null_or_whitespace_or_has_non_whitespace_value_then_return_false(string str1)
+        public void And_the_string_is_null_or_whitespace_or_has_non_whitespace_value_then_return_false(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsEmpty();
+            var result = str.IsEmpty();
 
             //-- Assert
             Assert.False(result);
@@ -322,13 +322,13 @@ public class StringExtensionsTests
         [InlineData(" . ")]
         [InlineData(" ")]
         [InlineData("      ")]
-        public void And_the_string_is_null_or_whitespace_or_has_non_whitespace_value_then_return_true(string str1)
+        public void And_the_string_is_null_or_whitespace_or_has_non_whitespace_value_then_return_true(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNotEmpty();
+            var result = str.IsNotEmpty();
 
             //-- Assert
             Assert.True(result);
@@ -336,16 +336,53 @@ public class StringExtensionsTests
 
         [Theory]
         [InlineData("")]
-        public void And_the_string_is_empty_only_then_return_false(string str1)
+        public void And_the_string_is_empty_only_then_return_false(string str)
         {
             //-- Arrange
             //-- <see InlineData>
 
             //-- Act
-            var result = str1.IsNotEmpty();
+            var result = str.IsNotEmpty();
 
             //-- Assert
             Assert.False(result);
+        }
+    }
+
+    public class When_calling_NullIfNullOrWhiteSpace
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("      ")]
+        public void And_the_string_is_null_or_whitespace_or_empty_then_return_null(string? str)
+        {
+            //-- Arrange
+            //-- <see InlineData>
+
+            //-- Act
+            var result = str.NullIfNullOrWhiteSpace();
+
+            //-- Assert
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("a")]
+        [InlineData(" b")]
+        [InlineData("c ")]
+        [InlineData(" d ")]
+        [InlineData(" . ")]
+        public void And_the_string_is_not_null_nor_whitespace_nor_empty_then_return_string(string str)
+        {
+            //-- Arrange
+            //-- <see InlineData>
+
+            //-- Act
+            var result = str.NullIfNullOrWhiteSpace();
+
+            //-- Assert
+            Assert.Equal(str, result);
         }
     }
 }

--- a/AGDevX/Strings/StringExtensions.cs
+++ b/AGDevX/Strings/StringExtensions.cs
@@ -117,4 +117,14 @@ public static class StringExtensions
     {
         return str != string.Empty;
     }
+
+    /// <summary>
+    /// Returns null if the string is null or whitespace
+    /// </summary>
+    /// <param name="str">String to check (required)</param>
+    /// <returns>Null if the string is null or whitespace. Otherwise, the string.</returns>
+    public static string? NullIfNullOrWhiteSpace([NotNullIfNotNull(nameof(str))] this string? str)
+    {
+        return str.IsNullOrWhiteSpace() ? null : str;
+    }
 }

--- a/AGDevX/Strings/StringExtensions.cs
+++ b/AGDevX/Strings/StringExtensions.cs
@@ -119,7 +119,7 @@ public static class StringExtensions
     }
 
     /// <summary>
-    /// Returns null if the string is null or whitespace
+    /// Returns null if the string is null or whitespace. Otherwise, returns the string.
     /// </summary>
     /// <param name="str">String to check (required)</param>
     /// <returns>Null if the string is null or whitespace. Otherwise, the string.</returns>

--- a/AGDevX/Strings/StringExtensions.cs
+++ b/AGDevX/Strings/StringExtensions.cs
@@ -123,7 +123,7 @@ public static class StringExtensions
     /// </summary>
     /// <param name="str">String to check (required)</param>
     /// <returns>Null if the string is null or whitespace. Otherwise, the string.</returns>
-    public static string? NullIfNullOrWhiteSpace([NotNullIfNotNull(nameof(str))] this string? str)
+    public static string? NullIfNullOrWhiteSpace(this string? str)
     {
         return str.IsNullOrWhiteSpace() ? null : str;
     }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2023 AGDevX .NET
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Extensions for pulling Claims out of a ClaimsPrincipal
 - `IsNotWhiteSpace`: Determines if a string contains at least one character that is not whitespace
 - `IsEmpty`: Determines if a string is empty
 - `IsNotEmpty`: Determines if a string is not empty
+- `NullIfNullOrWhiteSpace`: Returns null if the string is null or whitespace. Otherwise, returns the string.
 
 # Tech Debt
 


### PR DESCRIPTION
## Summary
- Returns null if string is null or whitespace, otherwise returns original string
- Removed incorrect [NotNullIfNotNull] attribute (whitespace strings return null despite being non-null)
- Includes tests and README update

## Test plan
- [ ] Null input returns null
- [ ] Empty string returns null
- [ ] Whitespace-only string returns null
- [ ] Non-whitespace string returns original string