### PR TITLE
Enable NuGet publishing in CI

### DIFF
--- a/.github/workflows/build-test-create-nuget-package.yml
+++ b/.github/workflows/build-test-create-nuget-package.yml
@@ -49,5 +49,5 @@ jobs:
         run: dotnet pack ${{ env.SOLUTION_PATH }} --configuration ${{ env.CONFIGURATION }} --include-symbols --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }} --no-restore --no-build
         #run: dotnet pack ${{ env.SOLUTION_PATH }} --configuration ${{ env.CONFIGURATION }} -p:PackageVersion=${{ steps.version.outputs.version-without-v }} --output ${{ env.PACKAGE_OUTPUT_DIRECTORY }} --no-restore --no-build --include-symbols
 
-      #- name: Push to NuGet.org
-      #  run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}\*.nupkg -s ${{ env.NUGET_API_URL }} -k ${{ secrets.NUGET_API_KEY }}
+      - name: Push to NuGet.org
+        run: dotnet nuget push ${{ env.PACKAGE_OUTPUT_DIRECTORY }}\*.nupkg -s ${{ env.NUGET_API_URL }} -k ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## Summary
- Uncomment the NuGet push step in the build workflow to enable automatic package publishing to NuGet.org

## Prerequisites
- `NUGET_API_KEY` secret must be configured in GitHub repository settings
- Without this secret, the push step will fail at runtime