### PR TITLE
Enable Roslyn code analyzers

### DIFF
--- a/AGDevX/AGDevX.csproj
+++ b/AGDevX/AGDevX.csproj
@@ -4,6 +4,15 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<EnableNETAnalyzers>true</EnableNETAnalyzers>
+		<AnalysisLevel>latest-recommended</AnalysisLevel>
+		<!--
+			CA1720: Extension method 'this' parameters that mirror their type (e.g., `this Guid guid`) are idiomatic;
+			        renaming them away from the type name would harm readability.
+			CA2208: AssemblyExtensions throws ArgumentNullException for a null property (assembly.FullName), not a
+			        parameter; the descriptive message string is intentional and correct.
+		-->
+		<NoWarn>$(NoWarn);CA1720;CA2208</NoWarn>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>AGDevX</Title>
 		<PackageProjectUrl>https://github.com/AGDevX/AGDevX.NET</PackageProjectUrl>

--- a/AGDevX/Security/ClaimsPrincipalExtensions.cs
+++ b/AGDevX/Security/ClaimsPrincipalExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using AGDevX.Enums;
@@ -72,7 +73,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.Expiration.StringValue());
         if (claim == null) return null;
-        return (int)Convert.ChangeType(claim.Value, typeof(int));
+        return (int)Convert.ChangeType(claim.Value, typeof(int), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -89,7 +90,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.NotBefore.StringValue());
         if (claim == null) return null;
-        return (int)Convert.ChangeType(claim.Value, typeof(int));
+        return (int)Convert.ChangeType(claim.Value, typeof(int), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -106,7 +107,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.IssuedAt.StringValue());
         if (claim == null) return null;
-        return (int)Convert.ChangeType(claim.Value, typeof(int));
+        return (int)Convert.ChangeType(claim.Value, typeof(int), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -291,7 +292,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.EmailVerified.StringValue());
         if (claim == null) return null;
-        return (bool)Convert.ChangeType(claim.Value, typeof(bool));
+        return (bool)Convert.ChangeType(claim.Value, typeof(bool), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -385,7 +386,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.PhoneNumberVerified.StringValue());
         if (claim == null) return null;
-        return (bool)Convert.ChangeType(claim.Value, typeof(bool));
+        return (bool)Convert.ChangeType(claim.Value, typeof(bool), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -419,7 +420,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.UpdatedAt.StringValue());
         if (claim == null) return null;
-        return (int)Convert.ChangeType(claim.Value, typeof(int));
+        return (int)Convert.ChangeType(claim.Value, typeof(int), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -466,7 +467,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.AuthTime.StringValue());
         if (claim == null) return null;
-        return (int)Convert.ChangeType(claim.Value, typeof(int));
+        return (int)Convert.ChangeType(claim.Value, typeof(int), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -621,7 +622,7 @@ public static class ClaimsPrincipalExtensions
     {
         var claim = claimsPrincipal.GetClaim(CustomClaimType.IsActive.StringValue());
         if (claim == null) return null;
-        return (bool)Convert.ChangeType(claim.Value, typeof(bool));
+        return (bool)Convert.ChangeType(claim.Value, typeof(bool), CultureInfo.InvariantCulture);
     }
 
     #endregion
@@ -652,7 +653,7 @@ public static class ClaimsPrincipalExtensions
             return default;
         }
 
-        return (T)Convert.ChangeType(claim.Value, typeof(T));
+        return (T)Convert.ChangeType(claim.Value, typeof(T), CultureInfo.InvariantCulture);
     }
 
     private static Claim? GetClaim(this ClaimsPrincipal claimsPrincipal, string claimType)
@@ -674,7 +675,7 @@ public static class ClaimsPrincipalExtensions
             return default;
         }
 
-        return claims!.Select(c => (T)Convert.ChangeType(c.Value, typeof(T))).ToList();
+        return claims!.Select(c => (T)Convert.ChangeType(c.Value, typeof(T), CultureInfo.InvariantCulture)).ToList();
     }
 
     private static List<Claim>? GetClaims(this ClaimsPrincipal claimsPrincipal, string claimType)


### PR DESCRIPTION
## Summary

- Enable `.NET` analyzers at `latest-recommended` level (`EnableNETAnalyzers=true`, `AnalysisLevel=latest-recommended`) in `AGDevX.csproj`
- Fix CA1305: pass `CultureInfo.InvariantCulture` to all `Convert.ChangeType` calls in `ClaimsPrincipalExtensions.cs` (10 call sites across JWT numeric date and boolean claim conversions)
- Suppress CA1720 and CA2208 via `<NoWarn>` in the csproj, with an explanatory comment for each

## Warnings surfaced and how they were resolved

| Rule | Count | Resolution |
|------|-------|------------|
| CA1305 — `Convert.ChangeType` without `IFormatProvider` | 10 | Fixed: pass `CultureInfo.InvariantCulture` |
| CA1720 — identifier contains type name (`guid`) | 6 | Suppressed: `this Guid guid` is idiomatic for `Guid` extension methods |
| CA2208 — `ArgumentNullException` paramName is not a parameter name | 1 | Suppressed: the null value is on `assembly.FullName` (a property), not a parameter; descriptive message is intentional |

## Test plan

- [x] `dotnet build AGDevX/AGDevX.csproj -c Release --no-incremental` — 0 warnings, 0 errors
- [x] `dotnet test AGDevX.Tests -v n` — 323 tests passed, 0 failed