### PR TITLE
Implement Birthdate and Address claim parsing

### DIFF
--- a/AGDevX.Tests/Security/ClaimsPrincipalExtensionsGetTests.cs
+++ b/AGDevX.Tests/Security/ClaimsPrincipalExtensionsGetTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Text.Json;
 using AGDevX.Exceptions;
 using AGDevX.Security;
 using Xunit;
@@ -373,6 +375,19 @@ public sealed class ClaimsPrincipalExtensionsGetTests
     public class When_calling_GetBirthdate
     {
         [Fact]
+        public void And_the_claim_exists_with_a_valid_date_then_return_parsed_DateTime()
+        {
+            //-- Arrange
+            var cp = CreatePrincipal(new Claim("birthdate", "1990-06-15"));
+
+            //-- Act
+            var result = cp.GetBirthdate();
+
+            //-- Assert
+            Assert.Equal(new DateTime(1990, 6, 15), result);
+        }
+
+        [Fact]
         public void And_the_claim_is_missing_then_throw_ClaimNotFoundException()
         {
             Assert.Throws<ClaimNotFoundException>(() => EmptyPrincipal().GetBirthdate());
@@ -417,6 +432,20 @@ public sealed class ClaimsPrincipalExtensionsGetTests
 
     public class When_calling_GetAddress
     {
+        [Fact]
+        public void And_the_claim_exists_with_valid_JSON_then_return_parsed_JsonElement()
+        {
+            //-- Arrange
+            var cp = CreatePrincipal(new Claim("address", "{\"street_address\":\"123 Main St\",\"locality\":\"Anytown\"}"));
+
+            //-- Act
+            var result = cp.GetAddress();
+
+            //-- Assert
+            Assert.Equal("123 Main St", result.GetProperty("street_address").GetString());
+            Assert.Equal("Anytown", result.GetProperty("locality").GetString());
+        }
+
         [Fact]
         public void And_the_claim_is_missing_then_throw_ClaimNotFoundException()
         {

--- a/AGDevX.Tests/Security/ClaimsPrincipalExtensionsTryGetTests.cs
+++ b/AGDevX.Tests/Security/ClaimsPrincipalExtensionsTryGetTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Text.Json;
 using AGDevX.Security;
 using Xunit;
 
@@ -586,16 +588,42 @@ public sealed class ClaimsPrincipalExtensionsTryGetTests
     public class When_calling_TryGetBirthdate
     {
         [Fact]
-        public void And_the_claim_exists_then_return_claim_value()
+        public void And_the_claim_exists_with_a_valid_date_then_return_parsed_DateTime()
         {
-            var cp = CreatePrincipal(new Claim("birthdate", "1990-01-15"));
-            Assert.Equal("1990-01-15", cp.TryGetBirthdate());
+            //-- Arrange
+            var cp = CreatePrincipal(new Claim("birthdate", "1990-06-15"));
+
+            //-- Act
+            var result = cp.TryGetBirthdate();
+
+            //-- Assert
+            Assert.Equal(new DateTime(1990, 6, 15), result);
         }
 
         [Fact]
         public void And_the_claim_is_missing_then_return_null()
         {
-            Assert.Null(EmptyPrincipal().TryGetBirthdate());
+            //-- Arrange
+            var cp = EmptyPrincipal();
+
+            //-- Act
+            var result = cp.TryGetBirthdate();
+
+            //-- Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void And_the_claim_value_is_not_parseable_then_return_null()
+        {
+            //-- Arrange
+            var cp = CreatePrincipal(new Claim("birthdate", "not-a-date"));
+
+            //-- Act
+            var result = cp.TryGetBirthdate();
+
+            //-- Assert
+            Assert.Null(result);
         }
     }
 
@@ -666,16 +694,44 @@ public sealed class ClaimsPrincipalExtensionsTryGetTests
     public class When_calling_TryGetAddress
     {
         [Fact]
-        public void And_the_claim_exists_then_return_claim_value()
+        public void And_the_claim_exists_with_valid_JSON_then_return_parsed_JsonElement()
         {
-            var cp = CreatePrincipal(new Claim("address", "{\"street_address\":\"123 Main St\"}"));
-            Assert.Equal("{\"street_address\":\"123 Main St\"}", cp.TryGetAddress());
+            //-- Arrange
+            var cp = CreatePrincipal(new Claim("address", "{\"street_address\":\"123 Main St\",\"locality\":\"Anytown\"}"));
+
+            //-- Act
+            var result = cp.TryGetAddress();
+
+            //-- Assert
+            Assert.NotNull(result);
+            Assert.Equal("123 Main St", result.Value.GetProperty("street_address").GetString());
+            Assert.Equal("Anytown", result.Value.GetProperty("locality").GetString());
         }
 
         [Fact]
         public void And_the_claim_is_missing_then_return_null()
         {
-            Assert.Null(EmptyPrincipal().TryGetAddress());
+            //-- Arrange
+            var cp = EmptyPrincipal();
+
+            //-- Act
+            var result = cp.TryGetAddress();
+
+            //-- Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void And_the_claim_value_is_invalid_JSON_then_return_null()
+        {
+            //-- Arrange
+            var cp = CreatePrincipal(new Claim("address", "not valid json {{{"));
+
+            //-- Act
+            var result = cp.TryGetAddress();
+
+            //-- Assert
+            Assert.Null(result);
         }
     }
 

--- a/AGDevX/Security/ClaimsPrincipalExtensions.cs
+++ b/AGDevX/Security/ClaimsPrincipalExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
+using System.Text.Json;
 using AGDevX.Enums;
 using AGDevX.Exceptions;
 using AGDevX.IEnumerables;
@@ -314,17 +315,25 @@ public static class ClaimsPrincipalExtensions
 
     #region Birthdate
 
-    public static string GetBirthdate(this ClaimsPrincipal claimsPrincipal)
+    /// <summary>
+    /// Returns the Birthdate claim value parsed as a <see cref="DateTime"/>.
+    /// Throws <see cref="ClaimNotFoundException"/> if the claim is missing or cannot be parsed.
+    /// </summary>
+    public static DateTime GetBirthdate(this ClaimsPrincipal claimsPrincipal)
     {
-        //-- TODO: Parse into DateTime or return null
         return claimsPrincipal.TryGetBirthdate()
                     ?? throw new ClaimNotFoundException($"A Birthdate claim was not found");
     }
 
-    public static string? TryGetBirthdate(this ClaimsPrincipal claimsPrincipal)
+    /// <summary>
+    /// Returns the Birthdate claim value parsed as a <see cref="DateTime"/>,
+    /// or <see langword="null"/> if the claim is missing or the value cannot be parsed.
+    /// </summary>
+    public static DateTime? TryGetBirthdate(this ClaimsPrincipal claimsPrincipal)
     {
-        //-- TODO: Parse into DateTime or return null
-        return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Birthdate.StringValue());
+        var value = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Birthdate.StringValue());
+        if (value == null) return null;
+        return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date) ? date : null;
     }
 
     #endregion
@@ -393,17 +402,32 @@ public static class ClaimsPrincipalExtensions
 
     #region Address
 
-    public static string GetAddress(this ClaimsPrincipal claimsPrincipal)
+    /// <summary>
+    /// Returns the Address claim value parsed as a <see cref="JsonElement"/>.
+    /// Throws <see cref="ClaimNotFoundException"/> if the claim is missing or the value is not valid JSON.
+    /// </summary>
+    public static JsonElement GetAddress(this ClaimsPrincipal claimsPrincipal)
     {
-        //-- TODO: Deserialize into an object from JSON
         return claimsPrincipal.TryGetAddress()
                     ?? throw new ClaimNotFoundException($"An Address claim was not found");
     }
 
-    public static string? TryGetAddress(this ClaimsPrincipal claimsPrincipal)
+    /// <summary>
+    /// Returns the Address claim value parsed as a <see cref="JsonElement"/>,
+    /// or <see langword="null"/> if the claim is missing or the value is not valid JSON.
+    /// </summary>
+    public static JsonElement? TryGetAddress(this ClaimsPrincipal claimsPrincipal)
     {
-        //-- TODO: Deserialize into an object from JSON
-        return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Address.StringValue());
+        var value = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Address.StringValue());
+        if (value == null) return null;
+        try
+        {
+            return JsonDocument.Parse(value).RootElement;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Birthdate: parse string claim to DateTime via TryParse with InvariantCulture
- Address: parse JSON string claim to JsonElement
- Both follow existing Get/TryGet pattern
- Unparseable values return null (TryGet) or throw (Get)

## Test plan
- [x] Birthdate: valid date string returns DateTime
- [x] Birthdate: missing claim returns null / throws
- [x] Birthdate: unparseable string returns null
- [x] Address: valid JSON returns JsonElement
- [x] Address: missing claim returns null / throws
- [x] Address: invalid JSON returns null
- [x] All existing tests still pass (335 total)