### PR TITLE
Quality improvements: bug fixes, XML docs, multi-targeting, CI

### DIFF
--- a/.claude/NOTES.md
+++ b/.claude/NOTES.md
@@ -1,11 +1,1 @@
 # NOTES
-
-## Tech Debt
-
-- [ ] Document all ClaimsPrincipal extensions in README (there are 40+ Get/TryGet pairs; README only lists the section header)
-
-## Observations
-
-- ClaimsPrincipal test coverage appears complete for all existing Get/TryGet pairs (40 pairs, ~1627 lines of tests)
-- README tech debt item "Unit tests to cover all ClaimsPrincipal extensions" may be outdated — verify and remove if so
-- Feature branch `ag/NullIfNullOrWhiteSpace` exists with completed implementation; `[NotNullIfNotNull]` attribute is semantically incorrect and should be removed when merging

--- a/.github/workflows/build-test-create-nuget-package.yml
+++ b/.github/workflows/build-test-create-nuget-package.yml
@@ -4,6 +4,9 @@ name: Build, Test, Create NuGet Package
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   #push:
   #  tags:
   #    - 'v*'
@@ -30,7 +33,9 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore ${{ env.SOLUTION_PATH }}

--- a/AGDevX.Tests/AGDevX.Tests.csproj
+++ b/AGDevX.Tests/AGDevX.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 

--- a/AGDevX.Tests/Exceptions/AcquireTokenExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/AcquireTokenExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class AcquireTokenExceptionTests
             var defaultCode = "ACQUIRE_TOKEN_EXCEPTION";
 
             //-- Assert
-            Assert.True(new AcquireTokenException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new AcquireTokenException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class AcquireTokenExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new AcquireTokenException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new AcquireTokenException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class AcquireTokenExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new AcquireTokenException(message).Message.Equals(message));
+            Assert.Equal(message, new AcquireTokenException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class AcquireTokenExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new AcquireTokenException(message, innerException).Message.Equals(message));
-            Assert.True(new AcquireTokenException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new AcquireTokenException(message, innerException).Message);
+            Assert.Same(innerException, new AcquireTokenException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class AcquireTokenExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new AcquireTokenException(message, code, innerException).Message.Equals(message));
-            Assert.True(new AcquireTokenException(message, code, innerException).Code.Equals(code));
-            Assert.True(new AcquireTokenException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new AcquireTokenException(message, code, innerException).Message);
+            Assert.Equal(code, new AcquireTokenException(message, code, innerException).Code);
+            Assert.Same(innerException, new AcquireTokenException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/ApplicationStartupExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/ApplicationStartupExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class ApplicationStartupExceptionTests
             var defaultCode = "APPLICATION_STARTUP_EXCEPTION";
 
             //-- Assert
-            Assert.True(new ApplicationStartupException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new ApplicationStartupException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class ApplicationStartupExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new ApplicationStartupException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new ApplicationStartupException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class ApplicationStartupExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new ApplicationStartupException(message).Message.Equals(message));
+            Assert.Equal(message, new ApplicationStartupException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class ApplicationStartupExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ApplicationStartupException(message, innerException).Message.Equals(message));
-            Assert.True(new ApplicationStartupException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new ApplicationStartupException(message, innerException).Message);
+            Assert.Same(innerException, new ApplicationStartupException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class ApplicationStartupExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ApplicationStartupException(message, code, innerException).Message.Equals(message));
-            Assert.True(new ApplicationStartupException(message, code, innerException).Code.Equals(code));
-            Assert.True(new ApplicationStartupException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new ApplicationStartupException(message, code, innerException).Message);
+            Assert.Equal(code, new ApplicationStartupException(message, code, innerException).Code);
+            Assert.Same(innerException, new ApplicationStartupException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/ClaimNotFoundExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/ClaimNotFoundExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class ClaimNotFoundExceptionTests
             var defaultCode = "CLAIM_NOT_FOUND_EXCEPTION";
 
             //-- Assert
-            Assert.True(new ClaimNotFoundException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new ClaimNotFoundException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class ClaimNotFoundExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new ClaimNotFoundException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new ClaimNotFoundException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class ClaimNotFoundExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new ClaimNotFoundException(message).Message.Equals(message));
+            Assert.Equal(message, new ClaimNotFoundException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class ClaimNotFoundExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ClaimNotFoundException(message, innerException).Message.Equals(message));
-            Assert.True(new ClaimNotFoundException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new ClaimNotFoundException(message, innerException).Message);
+            Assert.Same(innerException, new ClaimNotFoundException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class ClaimNotFoundExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ClaimNotFoundException(message, code, innerException).Message.Equals(message));
-            Assert.True(new ClaimNotFoundException(message, code, innerException).Code.Equals(code));
-            Assert.True(new ClaimNotFoundException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new ClaimNotFoundException(message, code, innerException).Message);
+            Assert.Equal(code, new ClaimNotFoundException(message, code, innerException).Code);
+            Assert.Same(innerException, new ClaimNotFoundException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/CodedApplicationExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/CodedApplicationExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class CodedApplicationExceptionTests
             var defaultCode = "CODED_APPLICATION_EXCEPTION";
 
             //-- Assert
-            Assert.True(new CodedApplicationException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new CodedApplicationException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class CodedApplicationExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new CodedApplicationException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new CodedApplicationException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class CodedApplicationExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new CodedApplicationException(message).Message.Equals(message));
+            Assert.Equal(message, new CodedApplicationException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class CodedApplicationExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new CodedApplicationException(message, innerException).Message.Equals(message));
-            Assert.True(new CodedApplicationException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new CodedApplicationException(message, innerException).Message);
+            Assert.Same(innerException, new CodedApplicationException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class CodedApplicationExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new CodedApplicationException(message, code, innerException).Message.Equals(message));
-            Assert.True(new CodedApplicationException(message, code, innerException).Code.Equals(code));
-            Assert.True(new CodedApplicationException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new CodedApplicationException(message, code, innerException).Message);
+            Assert.Equal(code, new CodedApplicationException(message, code, innerException).Code);
+            Assert.Same(innerException, new CodedApplicationException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/ExtensionMethodExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/ExtensionMethodExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class ExtensionMethodExceptionTests
             var defaultCode = "EXTENSION_METHOD_EXCEPTION";
 
             //-- Assert
-            Assert.True(new ExtensionMethodException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new ExtensionMethodException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class ExtensionMethodExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new ExtensionMethodException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new ExtensionMethodException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class ExtensionMethodExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new ExtensionMethodException(message).Message.Equals(message));
+            Assert.Equal(message, new ExtensionMethodException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class ExtensionMethodExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ExtensionMethodException(message, innerException).Message.Equals(message));
-            Assert.True(new ExtensionMethodException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new ExtensionMethodException(message, innerException).Message);
+            Assert.Same(innerException, new ExtensionMethodException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class ExtensionMethodExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ExtensionMethodException(message, code, innerException).Message.Equals(message));
-            Assert.True(new ExtensionMethodException(message, code, innerException).Code.Equals(code));
-            Assert.True(new ExtensionMethodException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new ExtensionMethodException(message, code, innerException).Message);
+            Assert.Equal(code, new ExtensionMethodException(message, code, innerException).Code);
+            Assert.Same(innerException, new ExtensionMethodException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/ExtensionMethodParameterNullExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/ExtensionMethodParameterNullExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class ExtensionMethodParameterNullExceptionTests
             var defaultCode = "EXTENSION_METHOD_PARAMETER_NULL_EXCEPTION";
 
             //-- Assert
-            Assert.True(new ExtensionMethodParameterNullException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new ExtensionMethodParameterNullException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class ExtensionMethodParameterNullExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new ExtensionMethodParameterNullException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new ExtensionMethodParameterNullException("msg", code).Code);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ public sealed class ExtensionMethodParameterNullExceptionTests
             var message = "Value cannot be null. (Parameter 'argumentName')";
 
             //-- Assert
-            Assert.True(new ExtensionMethodParameterNullException(argumentName).Message.Equals(message));
+            Assert.Equal(message, new ExtensionMethodParameterNullException(argumentName).Message);
         }
 
         [Fact]
@@ -48,8 +48,8 @@ public sealed class ExtensionMethodParameterNullExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ExtensionMethodParameterNullException(message, innerException).Message.Equals(message));
-            Assert.True(new ExtensionMethodParameterNullException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new ExtensionMethodParameterNullException(message, innerException).Message);
+            Assert.Same(innerException, new ExtensionMethodParameterNullException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -62,9 +62,9 @@ public sealed class ExtensionMethodParameterNullExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new ExtensionMethodParameterNullException(message, code, innerException).Message.Equals(message));
-            Assert.True(new ExtensionMethodParameterNullException(message, code, innerException).Code.Equals(code));
-            Assert.True(new ExtensionMethodParameterNullException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new ExtensionMethodParameterNullException(message, code, innerException).Message);
+            Assert.Equal(code, new ExtensionMethodParameterNullException(message, code, innerException).Code);
+            Assert.Same(innerException, new ExtensionMethodParameterNullException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/MissingRequiredClaimExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/MissingRequiredClaimExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class MissingRequiredClaimExceptionTests
             var defaultCode = "MISSING_REQUIRED_CLAIM_EXCEPTION";
 
             //-- Assert
-            Assert.True(new MissingRequiredClaimException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new MissingRequiredClaimException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class MissingRequiredClaimExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new MissingRequiredClaimException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new MissingRequiredClaimException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class MissingRequiredClaimExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new MissingRequiredClaimException(message).Message.Equals(message));
+            Assert.Equal(message, new MissingRequiredClaimException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class MissingRequiredClaimExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new MissingRequiredClaimException(message, innerException).Message.Equals(message));
-            Assert.True(new MissingRequiredClaimException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new MissingRequiredClaimException(message, innerException).Message);
+            Assert.Same(innerException, new MissingRequiredClaimException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class MissingRequiredClaimExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new MissingRequiredClaimException(message, code, innerException).Message.Equals(message));
-            Assert.True(new MissingRequiredClaimException(message, code, innerException).Code.Equals(code));
-            Assert.True(new MissingRequiredClaimException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new MissingRequiredClaimException(message, code, innerException).Message);
+            Assert.Equal(code, new MissingRequiredClaimException(message, code, innerException).Code);
+            Assert.Same(innerException, new MissingRequiredClaimException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Exceptions/NotAuthorizedExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/NotAuthorizedExceptionTests.cs
@@ -15,7 +15,7 @@ public sealed class NotAuthorizedExceptionTests
             var defaultCode = "NOT_AUTHORIZED_EXCEPTION";
 
             //-- Assert
-            Assert.True(new NotAuthorizedException().Code.Equals(defaultCode));
+            Assert.Equal(defaultCode, new NotAuthorizedException().Code);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ public sealed class NotAuthorizedExceptionTests
             var code = "ex";
 
             //-- Assert
-            Assert.True(new NotAuthorizedException("msg", code).Code.Equals(code));
+            Assert.Equal(code, new NotAuthorizedException("msg", code).Code);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public sealed class NotAuthorizedExceptionTests
             var message = "Test message";
 
             //-- Assert
-            Assert.True(new NotAuthorizedException(message).Message.Equals(message));
+            Assert.Equal(message, new NotAuthorizedException(message).Message);
         }
 
         [Fact]
@@ -47,8 +47,8 @@ public sealed class NotAuthorizedExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new NotAuthorizedException(message, innerException).Message.Equals(message));
-            Assert.True(new NotAuthorizedException(message, innerException).InnerException == innerException);
+            Assert.Equal(message, new NotAuthorizedException(message, innerException).Message);
+            Assert.Same(innerException, new NotAuthorizedException(message, innerException).InnerException);
         }
 
         [Fact]
@@ -61,9 +61,9 @@ public sealed class NotAuthorizedExceptionTests
             var innerException = new Exception(innerExceptionMessage);
 
             //-- Assert
-            Assert.True(new NotAuthorizedException(message, code, innerException).Message.Equals(message));
-            Assert.True(new NotAuthorizedException(message, code, innerException).Code.Equals(code));
-            Assert.True(new NotAuthorizedException(message, code, innerException).InnerException == innerException);
+            Assert.Equal(message, new NotAuthorizedException(message, code, innerException).Message);
+            Assert.Equal(code, new NotAuthorizedException(message, code, innerException).Code);
+            Assert.Same(innerException, new NotAuthorizedException(message, code, innerException).InnerException);
         }
     }
 }

--- a/AGDevX.Tests/Strings/StringExtensionsTests.cs
+++ b/AGDevX.Tests/Strings/StringExtensionsTests.cs
@@ -204,6 +204,9 @@ public class StringExtensionsTests
         [Theory]
         [InlineData(" ")]
         [InlineData("        ")]
+        [InlineData("\t")]
+        [InlineData("\n")]
+        [InlineData("\t \n")]
         public void And_the_string_is_whitespace_then_return_true(string str)
         {
             //-- Arrange
@@ -260,6 +263,9 @@ public class StringExtensionsTests
         [Theory]
         [InlineData(" ")]
         [InlineData("        ")]
+        [InlineData("\t")]
+        [InlineData("\n")]
+        [InlineData("\t \n")]
         public void And_the_string_is_whitespace_only_then_return_false(string str)
         {
             //-- Arrange

--- a/AGDevX/AGDevX.csproj
+++ b/AGDevX/AGDevX.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/AGDevX/IEnumerables/IEnumerableExtensions.cs
+++ b/AGDevX/IEnumerables/IEnumerableExtensions.cs
@@ -30,7 +30,7 @@ public static class IEnumerableExtensions
     /// <param name="enumerable2">IEnumerable 2 to check against IEnumerable 1 (required)</param>
     /// <param name="stringComparer">StringComparer to use when comparing the strings (required)</param>
     /// <returns>True if two elements have a common element. Otherwise, false.</returns>
-    public static bool HasCommonStringElement(this IEnumerable<string> enumerable1, [AllowNull] IEnumerable<string> enumerable2, StringComparer? stringComparer = default)
+    public static bool HasCommonStringElement(this IEnumerable<string> enumerable1, IEnumerable<string> enumerable2, StringComparer? stringComparer = default)
     {
         if (enumerable2 == null)
         {
@@ -74,7 +74,7 @@ public static class IEnumerableExtensions
     /// <param name="str">String to check against the IEnumerable (required)</param>
     /// <param name="stringComparer">StringComparer to use when comparing the strings (required)</param>
     /// <returns>True if the IEnumerable conatins the provided string. Otherwise, false.</returns>
-    public static bool ContainsIgnoreCase(this IEnumerable<string?> strings, [AllowNull] string str, StringComparer? stringComparer = default)
+    public static bool ContainsIgnoreCase(this IEnumerable<string?> strings, string str, StringComparer? stringComparer = default)
     {
         if (str == null)
         {

--- a/AGDevX/Security/ClaimsPrincipalExtensions.cs
+++ b/AGDevX/Security/ClaimsPrincipalExtensions.cs
@@ -21,7 +21,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetIssuer(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetIssuer()
-                    ?? throw new ClaimNotFoundException($"An Issuer claim was not found");
+                    ?? throw new ClaimNotFoundException("An Issuer claim was not found");
     }
 
     public static string? TryGetIssuer(this ClaimsPrincipal claimsPrincipal)
@@ -36,7 +36,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetSubject(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetSubject()
-                    ?? throw new ClaimNotFoundException($"A Subject claim was not found");
+                    ?? throw new ClaimNotFoundException("A Subject claim was not found");
     }
 
     public static string? TryGetSubject(this ClaimsPrincipal claimsPrincipal)
@@ -52,7 +52,7 @@ public static class ClaimsPrincipalExtensions
     public static List<string> GetAudiences(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAudiences()
-                    ?? throw new ClaimNotFoundException($"An Audience claim was not found");
+                    ?? throw new ClaimNotFoundException("An Audience claim was not found");
     }
 
     public static List<string>? TryGetAudiences(this ClaimsPrincipal claimsPrincipal)
@@ -67,7 +67,7 @@ public static class ClaimsPrincipalExtensions
     public static int GetExpiration(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetExpiration()
-                    ?? throw new ClaimNotFoundException($"An Expiration claim was not found");
+                    ?? throw new ClaimNotFoundException("An Expiration claim was not found");
     }
 
     public static int? TryGetExpiration(this ClaimsPrincipal claimsPrincipal)
@@ -84,7 +84,7 @@ public static class ClaimsPrincipalExtensions
     public static int GetNotBefore(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetNotBefore()
-                    ?? throw new ClaimNotFoundException($"A NotBefore claim was not found");
+                    ?? throw new ClaimNotFoundException("A NotBefore claim was not found");
     }
 
     public static int? TryGetNotBefore(this ClaimsPrincipal claimsPrincipal)
@@ -101,7 +101,7 @@ public static class ClaimsPrincipalExtensions
     public static int GetIssuedAt(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetIssuedAt()
-                    ?? throw new ClaimNotFoundException($"An IssuedAt claim was not found");
+                    ?? throw new ClaimNotFoundException("An IssuedAt claim was not found");
     }
 
     public static int? TryGetIssuedAt(this ClaimsPrincipal claimsPrincipal)
@@ -118,7 +118,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetJwtId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetJwtId()
-                    ?? throw new ClaimNotFoundException($"A JwtId claim was not found");
+                    ?? throw new ClaimNotFoundException("A JwtId claim was not found");
     }
 
     public static string? TryGetJwtId(this ClaimsPrincipal claimsPrincipal)
@@ -133,7 +133,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetName()
-                    ?? throw new ClaimNotFoundException($"A Name claim was not found");
+                    ?? throw new ClaimNotFoundException("A Name claim was not found");
     }
 
     public static string? TryGetName(this ClaimsPrincipal claimsPrincipal)
@@ -148,7 +148,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetGivenName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetGivenName()
-                    ?? throw new ClaimNotFoundException($"A Given Name claim was not found");
+                    ?? throw new ClaimNotFoundException("A Given Name claim was not found");
     }
 
     public static string? TryGetGivenName(this ClaimsPrincipal claimsPrincipal)
@@ -164,7 +164,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetFamilyName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetFamilyName()
-                    ?? throw new ClaimNotFoundException($"A Family Name claim was not found");
+                    ?? throw new ClaimNotFoundException("A Family Name claim was not found");
     }
 
     public static string? TryGetFamilyName(this ClaimsPrincipal claimsPrincipal)
@@ -180,7 +180,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetMiddleName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetMiddleName()
-                    ?? throw new ClaimNotFoundException($"A Middle Name claim was not found");
+                    ?? throw new ClaimNotFoundException("A Middle Name claim was not found");
     }
 
     public static string? TryGetMiddleName(this ClaimsPrincipal claimsPrincipal)
@@ -195,7 +195,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetNickname(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetNickname()
-                    ?? throw new ClaimNotFoundException($"A Nickname claim was not found");
+                    ?? throw new ClaimNotFoundException("A Nickname claim was not found");
     }
 
     public static string? TryGetNickname(this ClaimsPrincipal claimsPrincipal)
@@ -210,7 +210,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetPreferredUsername(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPreferredUsername()
-                    ?? throw new ClaimNotFoundException($"A Preferred Username claim was not found");
+                    ?? throw new ClaimNotFoundException("A Preferred Username claim was not found");
     }
 
     public static string? TryGetPreferredUsername(this ClaimsPrincipal claimsPrincipal)
@@ -225,7 +225,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetProfile(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetProfile()
-                    ?? throw new ClaimNotFoundException($"A Profile claim was not found");
+                    ?? throw new ClaimNotFoundException("A Profile claim was not found");
     }
 
     public static string? TryGetProfile(this ClaimsPrincipal claimsPrincipal)
@@ -240,7 +240,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetPicture(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPicture()
-                    ?? throw new ClaimNotFoundException($"A Picture claim was not found");
+                    ?? throw new ClaimNotFoundException("A Picture claim was not found");
     }
 
     public static string? TryGetPicture(this ClaimsPrincipal claimsPrincipal)
@@ -255,7 +255,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetWebsite(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetWebsite()
-                    ?? throw new ClaimNotFoundException($"A Website claim was not found");
+                    ?? throw new ClaimNotFoundException("A Website claim was not found");
     }
 
     public static string? TryGetWebsite(this ClaimsPrincipal claimsPrincipal)
@@ -270,7 +270,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetEmail(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetEmail()
-                    ?? throw new ClaimNotFoundException($"An Email claim was not found");
+                    ?? throw new ClaimNotFoundException("An Email claim was not found");
     }
 
     public static string? TryGetEmail(this ClaimsPrincipal claimsPrincipal)
@@ -286,7 +286,7 @@ public static class ClaimsPrincipalExtensions
     public static bool GetEmailVerified(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetEmailVerified()
-                    ?? throw new ClaimNotFoundException($"An EmailVerified claim was not found");
+                    ?? throw new ClaimNotFoundException("An EmailVerified claim was not found");
     }
 
     public static bool? TryGetEmailVerified(this ClaimsPrincipal claimsPrincipal)
@@ -303,7 +303,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetGender(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetGender()
-                    ?? throw new ClaimNotFoundException($"A Gender claim was not found");
+                    ?? throw new ClaimNotFoundException("A Gender claim was not found");
     }
 
     public static string? TryGetGender(this ClaimsPrincipal claimsPrincipal)
@@ -322,7 +322,7 @@ public static class ClaimsPrincipalExtensions
     public static DateTime GetBirthdate(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetBirthdate()
-                    ?? throw new ClaimNotFoundException($"A Birthdate claim was not found");
+                    ?? throw new ClaimNotFoundException("A Birthdate claim was not found");
     }
 
     /// <summary>
@@ -343,7 +343,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetZoneInfo(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetZoneInfo()
-                    ?? throw new ClaimNotFoundException($"A ZoneInfo claim was not found");
+                    ?? throw new ClaimNotFoundException("A ZoneInfo claim was not found");
     }
 
     public static string? TryGetZoneInfo(this ClaimsPrincipal claimsPrincipal)
@@ -358,7 +358,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetLocale(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetLocale()
-                    ?? throw new ClaimNotFoundException($"A Locale claim was not found");
+                    ?? throw new ClaimNotFoundException("A Locale claim was not found");
     }
 
     public static string? TryGetLocale(this ClaimsPrincipal claimsPrincipal)
@@ -373,7 +373,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetPhoneNumber(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPhoneNumber()
-                    ?? throw new ClaimNotFoundException($"A PhoneNumber claim was not found");
+                    ?? throw new ClaimNotFoundException("A PhoneNumber claim was not found");
     }
 
     public static string? TryGetPhoneNumber(this ClaimsPrincipal claimsPrincipal)
@@ -388,7 +388,7 @@ public static class ClaimsPrincipalExtensions
     public static bool GetPhoneNumberVerified(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPhoneNumberVerified()
-                    ?? throw new ClaimNotFoundException($"A PhoneNumberVerified claim was not found");
+                    ?? throw new ClaimNotFoundException("A PhoneNumberVerified claim was not found");
     }
 
     public static bool? TryGetPhoneNumberVerified(this ClaimsPrincipal claimsPrincipal)
@@ -409,7 +409,7 @@ public static class ClaimsPrincipalExtensions
     public static JsonElement GetAddress(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAddress()
-                    ?? throw new ClaimNotFoundException($"An Address claim was not found");
+                    ?? throw new ClaimNotFoundException("An Address claim was not found");
     }
 
     /// <summary>
@@ -437,7 +437,7 @@ public static class ClaimsPrincipalExtensions
     public static int GetUpdatedAt(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetUpdatedAt()
-                    ?? throw new ClaimNotFoundException($"An UpdatedAt claim was not found");
+                    ?? throw new ClaimNotFoundException("An UpdatedAt claim was not found");
     }
 
     public static int? TryGetUpdatedAt(this ClaimsPrincipal claimsPrincipal)
@@ -454,7 +454,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetAuthorizedParty(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthorizedParty()
-                    ?? throw new ClaimNotFoundException($"An AuthorizedParty claim was not found");
+                    ?? throw new ClaimNotFoundException("An AuthorizedParty claim was not found");
     }
 
     public static string? TryGetAuthorizedParty(this ClaimsPrincipal claimsPrincipal)
@@ -469,7 +469,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetNonce(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetNonce()
-                    ?? throw new ClaimNotFoundException($"A Nonce claim was not found");
+                    ?? throw new ClaimNotFoundException("A Nonce claim was not found");
     }
 
     public static string? TryGetNonce(this ClaimsPrincipal claimsPrincipal)
@@ -484,7 +484,7 @@ public static class ClaimsPrincipalExtensions
     public static int GetAuthTime(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthTime()
-                    ?? throw new ClaimNotFoundException($"An AuthTime claim was not found");
+                    ?? throw new ClaimNotFoundException("An AuthTime claim was not found");
     }
 
     public static int? TryGetAuthTime(this ClaimsPrincipal claimsPrincipal)
@@ -501,7 +501,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetAccessTokenHash(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAccessTokenHash()
-                    ?? throw new ClaimNotFoundException($"An AccessTokenHash claim was not found");
+                    ?? throw new ClaimNotFoundException("An AccessTokenHash claim was not found");
     }
 
     public static string? TryGetAccessTokenHash(this ClaimsPrincipal claimsPrincipal)
@@ -516,7 +516,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetCodeHash(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetCodeHash()
-                    ?? throw new ClaimNotFoundException($"A CodeHash claim was not found");
+                    ?? throw new ClaimNotFoundException("A CodeHash claim was not found");
     }
 
     public static string? TryGetCodeHash(this ClaimsPrincipal claimsPrincipal)
@@ -531,7 +531,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetAuthenticationContextClassReference(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthenticationContextClassReference()
-                    ?? throw new ClaimNotFoundException($"An AuthenticationContextClassReference claim was not found");
+                    ?? throw new ClaimNotFoundException("An AuthenticationContextClassReference claim was not found");
     }
 
     public static string? TryGetAuthenticationContextClassReference(this ClaimsPrincipal claimsPrincipal)
@@ -546,7 +546,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetAuthenticationMethodsReference(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthenticationMethodsReference()
-                    ?? throw new ClaimNotFoundException($"An AuthenticationMethodsReference claim was not found");
+                    ?? throw new ClaimNotFoundException("An AuthenticationMethodsReference claim was not found");
     }
 
     public static string? TryGetAuthenticationMethodsReference(this ClaimsPrincipal claimsPrincipal)
@@ -561,7 +561,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetSessionId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetSessionId()
-                    ?? throw new ClaimNotFoundException($"A SessionId claim was not found");
+                    ?? throw new ClaimNotFoundException("A SessionId claim was not found");
     }
 
     public static string? TryGetSessionId(this ClaimsPrincipal claimsPrincipal)
@@ -576,7 +576,7 @@ public static class ClaimsPrincipalExtensions
     public static List<string> GetScopes(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetScopes()
-                    ?? throw new ClaimNotFoundException($"A Scope claim was not found");
+                    ?? throw new ClaimNotFoundException("A Scope claim was not found");
     }
 
     public static List<string>? TryGetScopes(this ClaimsPrincipal claimsPrincipal)
@@ -592,7 +592,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetClientId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetClientId()
-                    ?? throw new ClaimNotFoundException($"A ClientId claim was not found");
+                    ?? throw new ClaimNotFoundException("A ClientId claim was not found");
     }
 
     public static string? TryGetClientId(this ClaimsPrincipal claimsPrincipal)
@@ -607,7 +607,7 @@ public static class ClaimsPrincipalExtensions
     public static List<string> GetRoles(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetRoles()
-                    ?? throw new ClaimNotFoundException($"A Roles claim was not found");
+                    ?? throw new ClaimNotFoundException("A Roles claim was not found");
     }
 
     public static List<string>? TryGetRoles(this ClaimsPrincipal claimsPrincipal)
@@ -623,7 +623,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetExternalId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetExternalId()
-                    ?? throw new ClaimNotFoundException($"An External Id claim was not found");
+                    ?? throw new ClaimNotFoundException("An External Id claim was not found");
     }
 
     public static string? TryGetExternalId(this ClaimsPrincipal claimsPrincipal)
@@ -639,7 +639,7 @@ public static class ClaimsPrincipalExtensions
     public static bool GetIsActive(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetIsActive()
-                    ?? throw new ClaimNotFoundException($"An IsActive claim was not found");
+                    ?? throw new ClaimNotFoundException("An IsActive claim was not found");
     }
 
     public static bool? TryGetIsActive(this ClaimsPrincipal claimsPrincipal)
@@ -656,7 +656,7 @@ public static class ClaimsPrincipalExtensions
     public static string GetGrantType(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetGrantType()
-                    ?? throw new ClaimNotFoundException($"A Grant Type claim was not found");
+                    ?? throw new ClaimNotFoundException("A Grant Type claim was not found");
     }
 
     public static string? TryGetGrantType(this ClaimsPrincipal claimsPrincipal)

--- a/AGDevX/Security/ClaimsPrincipalExtensions.cs
+++ b/AGDevX/Security/ClaimsPrincipalExtensions.cs
@@ -416,6 +416,11 @@ public static class ClaimsPrincipalExtensions
     /// Returns the Address claim value parsed as a <see cref="JsonElement"/>,
     /// or <see langword="null"/> if the claim is missing or the value is not valid JSON.
     /// </summary>
+    /// <remarks>
+    /// The underlying <see cref="JsonDocument"/> is not disposed because <see cref="JsonElement"/>
+    /// becomes invalid after its parent document is disposed. Callers should not hold long-lived
+    /// references to the returned value in memory-sensitive scenarios.
+    /// </remarks>
     public static JsonElement? TryGetAddress(this ClaimsPrincipal claimsPrincipal)
     {
         var value = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Address.StringValue());

--- a/AGDevX/Security/ClaimsPrincipalExtensions.cs
+++ b/AGDevX/Security/ClaimsPrincipalExtensions.cs
@@ -18,12 +18,18 @@ public static class ClaimsPrincipalExtensions
 {
     #region Issuer
 
+    /// <summary>
+    /// Returns the Issuer claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetIssuer(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetIssuer()
                     ?? throw new ClaimNotFoundException("An Issuer claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Issuer claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetIssuer(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Issuer.StringValue());
@@ -33,12 +39,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Subject
 
+    /// <summary>
+    /// Returns the Subject claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetSubject(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetSubject()
                     ?? throw new ClaimNotFoundException("A Subject claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Subject claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetSubject(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Subject.StringValue())
@@ -49,12 +61,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Audience
 
+    /// <summary>
+    /// Returns the Audience claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static List<string> GetAudiences(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAudiences()
                     ?? throw new ClaimNotFoundException("An Audience claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Audience claim values as a list, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static List<string>? TryGetAudiences(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValues<string>(JwtClaimType.Audience.StringValue());
@@ -64,12 +82,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Expiration
 
+    /// <summary>
+    /// Returns the Expiration claim value as an integer. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static int GetExpiration(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetExpiration()
                     ?? throw new ClaimNotFoundException("An Expiration claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Expiration claim value as an integer, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static int? TryGetExpiration(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.Expiration.StringValue());
@@ -81,12 +105,18 @@ public static class ClaimsPrincipalExtensions
 
     #region NotBefore
 
+    /// <summary>
+    /// Returns the NotBefore claim value as an integer. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static int GetNotBefore(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetNotBefore()
                     ?? throw new ClaimNotFoundException("A NotBefore claim was not found");
     }
 
+    /// <summary>
+    /// Returns the NotBefore claim value as an integer, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static int? TryGetNotBefore(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.NotBefore.StringValue());
@@ -98,12 +128,18 @@ public static class ClaimsPrincipalExtensions
 
     #region IssuedAt
 
+    /// <summary>
+    /// Returns the IssuedAt claim value as an integer. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static int GetIssuedAt(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetIssuedAt()
                     ?? throw new ClaimNotFoundException("An IssuedAt claim was not found");
     }
 
+    /// <summary>
+    /// Returns the IssuedAt claim value as an integer, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static int? TryGetIssuedAt(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.IssuedAt.StringValue());
@@ -115,12 +151,18 @@ public static class ClaimsPrincipalExtensions
 
     #region JwtId
 
+    /// <summary>
+    /// Returns the JwtId claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetJwtId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetJwtId()
                     ?? throw new ClaimNotFoundException("A JwtId claim was not found");
     }
 
+    /// <summary>
+    /// Returns the JwtId claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetJwtId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.JwtId.StringValue());
@@ -130,12 +172,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Name
 
+    /// <summary>
+    /// Returns the Name claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetName()
                     ?? throw new ClaimNotFoundException("A Name claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Name claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Name.StringValue());
@@ -145,12 +193,18 @@ public static class ClaimsPrincipalExtensions
 
     #region GivenName
 
+    /// <summary>
+    /// Returns the GivenName claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetGivenName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetGivenName()
                     ?? throw new ClaimNotFoundException("A Given Name claim was not found");
     }
 
+    /// <summary>
+    /// Returns the GivenName claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetGivenName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.GivenName.StringValue())
@@ -161,12 +215,18 @@ public static class ClaimsPrincipalExtensions
 
     #region FamilyName
 
+    /// <summary>
+    /// Returns the FamilyName claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetFamilyName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetFamilyName()
                     ?? throw new ClaimNotFoundException("A Family Name claim was not found");
     }
 
+    /// <summary>
+    /// Returns the FamilyName claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetFamilyName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.FamilyName.StringValue())
@@ -177,12 +237,18 @@ public static class ClaimsPrincipalExtensions
 
     #region MiddleName
 
+    /// <summary>
+    /// Returns the MiddleName claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetMiddleName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetMiddleName()
                     ?? throw new ClaimNotFoundException("A Middle Name claim was not found");
     }
 
+    /// <summary>
+    /// Returns the MiddleName claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetMiddleName(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.MiddleName.StringValue());
@@ -192,12 +258,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Nickname
 
+    /// <summary>
+    /// Returns the Nickname claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetNickname(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetNickname()
                     ?? throw new ClaimNotFoundException("A Nickname claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Nickname claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetNickname(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Nickname.StringValue());
@@ -207,12 +279,18 @@ public static class ClaimsPrincipalExtensions
 
     #region PreferredUsername
 
+    /// <summary>
+    /// Returns the PreferredUsername claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetPreferredUsername(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPreferredUsername()
                     ?? throw new ClaimNotFoundException("A Preferred Username claim was not found");
     }
 
+    /// <summary>
+    /// Returns the PreferredUsername claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetPreferredUsername(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.PreferredUsername.StringValue());
@@ -222,12 +300,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Profile
 
+    /// <summary>
+    /// Returns the Profile claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetProfile(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetProfile()
                     ?? throw new ClaimNotFoundException("A Profile claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Profile claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetProfile(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Profile.StringValue());
@@ -237,12 +321,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Picture
 
+    /// <summary>
+    /// Returns the Picture claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetPicture(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPicture()
                     ?? throw new ClaimNotFoundException("A Picture claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Picture claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetPicture(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Picture.StringValue());
@@ -252,12 +342,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Website
 
+    /// <summary>
+    /// Returns the Website claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetWebsite(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetWebsite()
                     ?? throw new ClaimNotFoundException("A Website claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Website claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetWebsite(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Website.StringValue());
@@ -267,12 +363,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Email
 
+    /// <summary>
+    /// Returns the Email claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetEmail(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetEmail()
                     ?? throw new ClaimNotFoundException("An Email claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Email claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetEmail(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Email.StringValue())
@@ -283,12 +385,18 @@ public static class ClaimsPrincipalExtensions
 
     #region EmailVerified
 
+    /// <summary>
+    /// Returns the EmailVerified claim value as a boolean. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static bool GetEmailVerified(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetEmailVerified()
                     ?? throw new ClaimNotFoundException("An EmailVerified claim was not found");
     }
 
+    /// <summary>
+    /// Returns the EmailVerified claim value as a boolean, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static bool? TryGetEmailVerified(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.EmailVerified.StringValue());
@@ -300,12 +408,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Gender
 
+    /// <summary>
+    /// Returns the Gender claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetGender(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetGender()
                     ?? throw new ClaimNotFoundException("A Gender claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Gender claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetGender(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Gender.StringValue());
@@ -340,12 +454,18 @@ public static class ClaimsPrincipalExtensions
 
     #region ZoneInfo
 
+    /// <summary>
+    /// Returns the ZoneInfo claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetZoneInfo(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetZoneInfo()
                     ?? throw new ClaimNotFoundException("A ZoneInfo claim was not found");
     }
 
+    /// <summary>
+    /// Returns the ZoneInfo claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetZoneInfo(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.ZoneInfo.StringValue());
@@ -355,12 +475,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Locale
 
+    /// <summary>
+    /// Returns the Locale claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetLocale(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetLocale()
                     ?? throw new ClaimNotFoundException("A Locale claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Locale claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetLocale(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Locale.StringValue());
@@ -370,12 +496,18 @@ public static class ClaimsPrincipalExtensions
 
     #region PhoneNumber
 
+    /// <summary>
+    /// Returns the PhoneNumber claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetPhoneNumber(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPhoneNumber()
                     ?? throw new ClaimNotFoundException("A PhoneNumber claim was not found");
     }
 
+    /// <summary>
+    /// Returns the PhoneNumber claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetPhoneNumber(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.PhoneNumber.StringValue());
@@ -385,12 +517,18 @@ public static class ClaimsPrincipalExtensions
 
     #region PhoneNumberVerified
 
+    /// <summary>
+    /// Returns the PhoneNumberVerified claim value as a boolean. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static bool GetPhoneNumberVerified(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetPhoneNumberVerified()
                     ?? throw new ClaimNotFoundException("A PhoneNumberVerified claim was not found");
     }
 
+    /// <summary>
+    /// Returns the PhoneNumberVerified claim value as a boolean, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static bool? TryGetPhoneNumberVerified(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.PhoneNumberVerified.StringValue());
@@ -439,12 +577,18 @@ public static class ClaimsPrincipalExtensions
 
     #region UpdatedAt
 
+    /// <summary>
+    /// Returns the UpdatedAt claim value as an integer. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static int GetUpdatedAt(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetUpdatedAt()
                     ?? throw new ClaimNotFoundException("An UpdatedAt claim was not found");
     }
 
+    /// <summary>
+    /// Returns the UpdatedAt claim value as an integer, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static int? TryGetUpdatedAt(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.UpdatedAt.StringValue());
@@ -456,12 +600,18 @@ public static class ClaimsPrincipalExtensions
 
     #region AuthorizedParty
 
+    /// <summary>
+    /// Returns the AuthorizedParty claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetAuthorizedParty(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthorizedParty()
                     ?? throw new ClaimNotFoundException("An AuthorizedParty claim was not found");
     }
 
+    /// <summary>
+    /// Returns the AuthorizedParty claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetAuthorizedParty(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.AuthorizedParty.StringValue());
@@ -471,12 +621,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Nonce
 
+    /// <summary>
+    /// Returns the Nonce claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetNonce(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetNonce()
                     ?? throw new ClaimNotFoundException("A Nonce claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Nonce claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetNonce(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.Nonce.StringValue());
@@ -486,12 +642,18 @@ public static class ClaimsPrincipalExtensions
 
     #region AuthTime
 
+    /// <summary>
+    /// Returns the AuthTime claim value as an integer. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static int GetAuthTime(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthTime()
                     ?? throw new ClaimNotFoundException("An AuthTime claim was not found");
     }
 
+    /// <summary>
+    /// Returns the AuthTime claim value as an integer, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static int? TryGetAuthTime(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(JwtClaimType.AuthTime.StringValue());
@@ -503,12 +665,18 @@ public static class ClaimsPrincipalExtensions
 
     #region AccessTokenHash
 
+    /// <summary>
+    /// Returns the AccessTokenHash claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetAccessTokenHash(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAccessTokenHash()
                     ?? throw new ClaimNotFoundException("An AccessTokenHash claim was not found");
     }
 
+    /// <summary>
+    /// Returns the AccessTokenHash claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetAccessTokenHash(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.AccessTokenHash.StringValue());
@@ -518,12 +686,18 @@ public static class ClaimsPrincipalExtensions
 
     #region CodeHash
 
+    /// <summary>
+    /// Returns the CodeHash claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetCodeHash(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetCodeHash()
                     ?? throw new ClaimNotFoundException("A CodeHash claim was not found");
     }
 
+    /// <summary>
+    /// Returns the CodeHash claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetCodeHash(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.CodeHash.StringValue());
@@ -533,12 +707,18 @@ public static class ClaimsPrincipalExtensions
 
     #region AuthenticationContextClassReference
 
+    /// <summary>
+    /// Returns the AuthenticationContextClassReference claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetAuthenticationContextClassReference(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthenticationContextClassReference()
                     ?? throw new ClaimNotFoundException("An AuthenticationContextClassReference claim was not found");
     }
 
+    /// <summary>
+    /// Returns the AuthenticationContextClassReference claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetAuthenticationContextClassReference(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.AuthenticationContextClassReference.StringValue());
@@ -548,12 +728,18 @@ public static class ClaimsPrincipalExtensions
 
     #region AuthenticationMethodsReference
 
+    /// <summary>
+    /// Returns the AuthenticationMethodsReference claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetAuthenticationMethodsReference(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAuthenticationMethodsReference()
                     ?? throw new ClaimNotFoundException("An AuthenticationMethodsReference claim was not found");
     }
 
+    /// <summary>
+    /// Returns the AuthenticationMethodsReference claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetAuthenticationMethodsReference(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.AuthenticationMethodsReference.StringValue());
@@ -563,12 +749,18 @@ public static class ClaimsPrincipalExtensions
 
     #region SessionId
 
+    /// <summary>
+    /// Returns the SessionId claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetSessionId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetSessionId()
                     ?? throw new ClaimNotFoundException("A SessionId claim was not found");
     }
 
+    /// <summary>
+    /// Returns the SessionId claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetSessionId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.SessionId.StringValue());
@@ -578,12 +770,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Scope
 
+    /// <summary>
+    /// Returns the Scope claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static List<string> GetScopes(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetScopes()
                     ?? throw new ClaimNotFoundException("A Scope claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Scope claim values as a list, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static List<string>? TryGetScopes(this ClaimsPrincipal claimsPrincipal)
     {
         var scopeStr = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Scope.StringValue());
@@ -594,12 +792,18 @@ public static class ClaimsPrincipalExtensions
 
     #region ClientId
 
+    /// <summary>
+    /// Returns the ClientId claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetClientId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetClientId()
                     ?? throw new ClaimNotFoundException("A ClientId claim was not found");
     }
 
+    /// <summary>
+    /// Returns the ClientId claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetClientId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(JwtClaimType.ClientId.StringValue());
@@ -609,12 +813,18 @@ public static class ClaimsPrincipalExtensions
 
     #region Roles
 
+    /// <summary>
+    /// Returns the Roles claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static List<string> GetRoles(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetRoles()
                     ?? throw new ClaimNotFoundException("A Roles claim was not found");
     }
 
+    /// <summary>
+    /// Returns the Roles claim values as a list, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static List<string>? TryGetRoles(this ClaimsPrincipal claimsPrincipal)
     {
         var rolesStr = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Roles.StringValue());
@@ -625,12 +835,18 @@ public static class ClaimsPrincipalExtensions
 
     #region ExternalId
 
+    /// <summary>
+    /// Returns the ExternalId claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetExternalId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetExternalId()
                     ?? throw new ClaimNotFoundException("An External Id claim was not found");
     }
 
+    /// <summary>
+    /// Returns the ExternalId claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetExternalId(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetSubject()
@@ -641,12 +857,18 @@ public static class ClaimsPrincipalExtensions
 
     #region IsActive
 
+    /// <summary>
+    /// Returns the IsActive claim value as a boolean. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static bool GetIsActive(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetIsActive()
                     ?? throw new ClaimNotFoundException("An IsActive claim was not found");
     }
 
+    /// <summary>
+    /// Returns the IsActive claim value as a boolean, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static bool? TryGetIsActive(this ClaimsPrincipal claimsPrincipal)
     {
         var claim = claimsPrincipal.GetClaim(CustomClaimType.IsActive.StringValue());
@@ -658,12 +880,18 @@ public static class ClaimsPrincipalExtensions
 
     #region GrantType
 
+    /// <summary>
+    /// Returns the GrantType claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// </summary>
     public static string GetGrantType(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetGrantType()
                     ?? throw new ClaimNotFoundException("A Grant Type claim was not found");
     }
 
+    /// <summary>
+    /// Returns the GrantType claim value, or <see langword="null"/> if the claim is missing.
+    /// </summary>
     public static string? TryGetGrantType(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValue<string>(Auth0ClaimType.GrantType.StringValue());

--- a/AGDevX/Strings/StringExtensions.cs
+++ b/AGDevX/Strings/StringExtensions.cs
@@ -85,7 +85,7 @@ public static class StringExtensions
     /// <returns>True if the string only consists of whitespace. Otherwise, false.</returns>
     public static bool IsWhiteSpace([NotNullWhen(true)] this string str)
     {
-        return str != string.Empty && str.All(s => s == ' ');
+        return str != string.Empty && str.All(char.IsWhiteSpace);
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public static class StringExtensions
     /// <returns>True if a string contains at least one character that is not whitespace. Otherwise, false.</returns>
     public static bool IsNotWhiteSpace([MaybeNullWhen(true)] this string str)
     {
-        return str == string.Empty || !str.All(s => s == ' ');
+        return str == string.Empty || !str.All(char.IsWhiteSpace);
     }
 
     /// <summary>

--- a/AGDevX/Strings/StringExtensions.cs
+++ b/AGDevX/Strings/StringExtensions.cs
@@ -14,7 +14,7 @@ public static class StringExtensions
     /// <param name="string2">String 2 to compare to string 1 (required)</param>
     /// <param name="stringComparison">StringComparison to use when comparing the strings (required)</param>
     /// <returns>True if the two strings are equal ignoring the case. Otherwise, false.</returns>
-    public static bool EqualsIgnoreCase(this string string1, [AllowNull] string string2, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
+    public static bool EqualsIgnoreCase(this string string1, string string2, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
     {
         if (string2 == null)
         {
@@ -31,7 +31,7 @@ public static class StringExtensions
     /// <param name="string2">String 2 used to compare to string 1 (required)</param>
     /// <param name="stringComparison">StringComparison to use when comparing the strings (required)</param>
     /// <returns>True if string 1 starts with string 2 ignoring case. Otherwise, false.</returns>
-    public static bool StartsWithIgnoreCase(this string string1, [AllowNull] string string2, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
+    public static bool StartsWithIgnoreCase(this string string1, string string2, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
     {
         if (string2 == null)
         {
@@ -48,7 +48,7 @@ public static class StringExtensions
     /// <param name="string2">String 2 to determine if it is contained in string 1 (required)</param>
     /// <param name="stringComparison">StringComparison to use when comparing the strings (required)</param>
     /// <returns>True if string 1 contains string 2 ignoring case. Otherwise, false.</returns>
-    public static bool ContainsIgnoreCase(this string string1, [AllowNull] string string2, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
+    public static bool ContainsIgnoreCase(this string string1, string string2, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase)
     {
         if (string2 == null)
         {

--- a/README.md
+++ b/README.md
@@ -101,7 +101,65 @@ Information relevant to a developer that has been extracted from an execption an
 
 ### ClaimsPrincipal Extensions
 
-Extensions for pulling Claims out of a ClaimsPrincipal
+Extensions for pulling Claims out of a ClaimsPrincipal. Each claim has a `Get` variant (throws `ClaimNotFoundException` if missing) and a `TryGet` variant (returns null if missing).
+
+#### Standard JWT Claims
+
+- `GetIssuer` / `TryGetIssuer`: Returns the Issuer (iss) claim value
+- `GetSubject` / `TryGetSubject`: Returns the Subject (sub) claim value
+- `GetAudiences` / `TryGetAudiences`: Returns the Audience (aud) claim values as a list
+- `GetExpiration` / `TryGetExpiration`: Returns the Expiration (exp) claim value as an integer
+- `GetNotBefore` / `TryGetNotBefore`: Returns the NotBefore (nbf) claim value as an integer
+- `GetIssuedAt` / `TryGetIssuedAt`: Returns the IssuedAt (iat) claim value as an integer
+- `GetJwtId` / `TryGetJwtId`: Returns the JWT ID (jti) claim value
+
+#### OpenID Connect Profile Claims
+
+- `GetName` / `TryGetName`: Returns the Name claim value
+- `GetGivenName` / `TryGetGivenName`: Returns the Given Name claim value
+- `GetFamilyName` / `TryGetFamilyName`: Returns the Family Name claim value
+- `GetMiddleName` / `TryGetMiddleName`: Returns the Middle Name claim value
+- `GetNickname` / `TryGetNickname`: Returns the Nickname claim value
+- `GetPreferredUsername` / `TryGetPreferredUsername`: Returns the Preferred Username claim value
+- `GetProfile` / `TryGetProfile`: Returns the Profile claim value
+- `GetPicture` / `TryGetPicture`: Returns the Picture claim value
+- `GetWebsite` / `TryGetWebsite`: Returns the Website claim value
+- `GetGender` / `TryGetGender`: Returns the Gender claim value
+- `GetBirthdate` / `TryGetBirthdate`: Returns the Birthdate claim value as a DateTime
+- `GetZoneInfo` / `TryGetZoneInfo`: Returns the ZoneInfo claim value
+- `GetLocale` / `TryGetLocale`: Returns the Locale claim value
+- `GetUpdatedAt` / `TryGetUpdatedAt`: Returns the UpdatedAt claim value as an integer
+
+#### OpenID Connect Contact Claims
+
+- `GetEmail` / `TryGetEmail`: Returns the Email claim value
+- `GetEmailVerified` / `TryGetEmailVerified`: Returns the EmailVerified claim value as a boolean
+- `GetPhoneNumber` / `TryGetPhoneNumber`: Returns the PhoneNumber claim value
+- `GetPhoneNumberVerified` / `TryGetPhoneNumberVerified`: Returns the PhoneNumberVerified claim value as a boolean
+- `GetAddress` / `TryGetAddress`: Returns the Address claim value as a JsonElement
+
+#### OpenID Connect Authentication Claims
+
+- `GetAuthorizedParty` / `TryGetAuthorizedParty`: Returns the Authorized Party (azp) claim value
+- `GetNonce` / `TryGetNonce`: Returns the Nonce claim value
+- `GetAuthTime` / `TryGetAuthTime`: Returns the Auth Time claim value as an integer
+- `GetAccessTokenHash` / `TryGetAccessTokenHash`: Returns the Access Token Hash (at_hash) claim value
+- `GetCodeHash` / `TryGetCodeHash`: Returns the Code Hash (c_hash) claim value
+- `GetAuthenticationContextClassReference` / `TryGetAuthenticationContextClassReference`: Returns the Authentication Context Class Reference (acr) claim value
+- `GetAuthenticationMethodsReference` / `TryGetAuthenticationMethodsReference`: Returns the Authentication Methods Reference (amr) claim value
+- `GetSessionId` / `TryGetSessionId`: Returns the Session ID (sid) claim value
+
+#### OAuth 2.0 Claims
+
+- `GetScopes` / `TryGetScopes`: Returns the Scope claim values as a list
+- `GetClientId` / `TryGetClientId`: Returns the Client ID claim value
+- `GetRoles` / `TryGetRoles`: Returns the Roles claim values as a list
+
+#### Custom / Provider-Specific Claims
+
+- `GetExternalId` / `TryGetExternalId`: Returns an external identifier (tries Subject, then UserId)
+- `GetIsActive` / `TryGetIsActive`: Returns the IsActive claim value as a boolean
+- `GetGrantType` / `TryGetGrantType`: Returns the Grant Type claim value (Auth0-specific)
 
 ## Strings
 
@@ -118,6 +176,3 @@ Extensions for pulling Claims out of a ClaimsPrincipal
 - `IsNotEmpty`: Determines if a string is not empty
 - `NullIfNullOrWhiteSpace`: Returns null if the string is null or whitespace. Otherwise, returns the string.
 
-# Tech Debt
-
-- Document all `ClaimsPrincipal` extensions (there are many)

--- a/docs/plans/2026-03-01-quality-improvements.md
+++ b/docs/plans/2026-03-01-quality-improvements.md
@@ -1,0 +1,385 @@
+# Quality Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix bugs, add missing XML docs, improve test assertions, add multi-targeting, update CI, and complete README documentation.
+
+**Architecture:** These are independent quality improvements across the existing codebase. No new projects or architectural changes. Each task is self-contained.
+
+**Tech Stack:** C# / .NET 10 + .NET 8 / xUnit
+
+---
+
+### Task 1: Fix `IsWhiteSpace`/`IsNotWhiteSpace` bug
+
+The methods only check for space characters (`' '`), not tabs, newlines, or other Unicode whitespace.
+
+**Files:**
+- Modify: `AGDevX/Strings/StringExtensions.cs:88,98`
+- Modify: `AGDevX.Tests/Strings/StringExtensionsTests.cs:205,262`
+
+**Step 1: Add failing test cases for tab/newline whitespace**
+
+In `AGDevX.Tests/Strings/StringExtensionsTests.cs`, add `\t` and `\n` InlineData to the `When_calling_IsWhiteSpace` true cases and `When_calling_IsNotWhiteSpace` false cases:
+
+```csharp
+// In When_calling_IsWhiteSpace, add to the "return_true" test:
+[InlineData("\t")]
+[InlineData("\n")]
+[InlineData("\t \n")]
+
+// In When_calling_IsNotWhiteSpace, add to the "return_false" test:
+[InlineData("\t")]
+[InlineData("\n")]
+[InlineData("\t \n")]
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~When_calling_IsWhiteSpace|FullyQualifiedName~When_calling_IsNotWhiteSpace" --no-build --verbosity normal`
+Expected: FAIL — `"\t".IsWhiteSpace()` returns false
+
+**Step 3: Fix implementation**
+
+In `AGDevX/Strings/StringExtensions.cs`, change:
+
+Line 88 — `IsWhiteSpace`:
+```csharp
+// FROM:
+return str != string.Empty && str.All(s => s == ' ');
+// TO:
+return str != string.Empty && str.All(char.IsWhiteSpace);
+```
+
+Line 98 — `IsNotWhiteSpace`:
+```csharp
+// FROM:
+return str == string.Empty || !str.All(s => s == ' ');
+// TO:
+return str == string.Empty || !str.All(char.IsWhiteSpace);
+```
+
+**Step 4: Build and run tests to verify they pass**
+
+Run: `dotnet build && dotnet test --verbosity normal`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```
+fix: use char.IsWhiteSpace instead of checking only for space character
+
+IsWhiteSpace/IsNotWhiteSpace only detected spaces, not tabs, newlines,
+or other Unicode whitespace characters.
+```
+
+---
+
+### Task 2: Remove `[AllowNull]` from parameters that throw on null
+
+`[AllowNull]` signals to callers that null is acceptable, but these methods throw on null. Remove the attribute so the API contract matches the behavior.
+
+**Files:**
+- Modify: `AGDevX/Strings/StringExtensions.cs:17,34,51`
+- Modify: `AGDevX/IEnumerables/IEnumerableExtensions.cs:33,77`
+
+**Step 1: Remove `[AllowNull]` from throwing parameters**
+
+In `StringExtensions.cs`, remove `[AllowNull]` from `string2` parameter on:
+- `EqualsIgnoreCase` (line 17)
+- `StartsWithIgnoreCase` (line 34)
+- `ContainsIgnoreCase` (line 51)
+
+In `IEnumerableExtensions.cs`, remove `[AllowNull]` from:
+- `enumerable2` on `HasCommonStringElement` (line 33)
+- `str` on `ContainsIgnoreCase` (line 77)
+
+**Step 2: Build and run tests**
+
+Run: `dotnet build && dotnet test --verbosity normal`
+Expected: All tests PASS (behavior unchanged, only nullability annotation corrected)
+
+**Step 3: Commit**
+
+```
+fix: remove [AllowNull] from parameters that throw on null
+
+The attribute signaled to callers that null was acceptable, but the
+methods immediately throw. Now the API contract matches behavior.
+```
+
+---
+
+### Task 3: Remove unnecessary `$` string interpolation in ClaimsPrincipalExtensions
+
+All throw expressions use `$"..."` with no interpolated expressions.
+
+**Files:**
+- Modify: `AGDevX/Security/ClaimsPrincipalExtensions.cs`
+
+**Step 1: Remove `$` prefix from all non-interpolated strings**
+
+Replace all `$"A ... claim was not found"` with `"A ... claim was not found"` (34 occurrences).
+
+**Step 2: Build and run tests**
+
+Run: `dotnet build && dotnet test --verbosity normal`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```
+cleanup: remove unnecessary $ string interpolation prefix
+
+None of the exception message strings contained interpolated expressions.
+```
+
+---
+
+### Task 4: Document `TryGetAddress` JsonDocument disposal trade-off
+
+**Files:**
+- Modify: `AGDevX/Security/ClaimsPrincipalExtensions.cs:419-431`
+
+**Step 1: Add XML doc comment explaining the trade-off**
+
+Update the existing `TryGetAddress` XML doc to note the disposal trade-off:
+
+```csharp
+/// <summary>
+/// Returns the Address claim value parsed as a <see cref="JsonElement"/>,
+/// or <see langword="null"/> if the claim is missing or the value is not valid JSON.
+/// </summary>
+/// <remarks>
+/// The underlying <see cref="JsonDocument"/> is not disposed because <see cref="JsonElement"/>
+/// becomes invalid after its parent document is disposed. Callers should not hold long-lived
+/// references to the returned value in memory-sensitive scenarios.
+/// </remarks>
+```
+
+**Step 2: Commit**
+
+```
+docs: document TryGetAddress JsonDocument disposal trade-off
+```
+
+---
+
+### Task 5: Add missing XML docs to ClaimsPrincipal methods
+
+36 of the 40 Get/TryGet method pairs lack XML documentation. Only Birthdate and Address have them.
+
+**Files:**
+- Modify: `AGDevX/Security/ClaimsPrincipalExtensions.cs`
+
+**Step 1: Add XML docs to all undocumented public methods**
+
+Every `Get{Claim}` method gets:
+```csharp
+/// <summary>
+/// Returns the {Claim} claim value. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+/// </summary>
+```
+
+Every `TryGet{Claim}` method gets:
+```csharp
+/// <summary>
+/// Returns the {Claim} claim value, or <see langword="null"/> if the claim is missing.
+/// </summary>
+```
+
+For methods returning `List<string>` (Audiences, Scopes, Roles):
+```csharp
+/// <summary>
+/// Returns the {Claim} claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+/// </summary>
+```
+
+For methods returning `int` (Expiration, NotBefore, IssuedAt, UpdatedAt, AuthTime):
+```csharp
+/// <summary>
+/// Returns the {Claim} claim value as an integer. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+/// </summary>
+```
+
+For methods returning `bool` (EmailVerified, PhoneNumberVerified, IsActive):
+```csharp
+/// <summary>
+/// Returns the {Claim} claim value as a boolean. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+/// </summary>
+```
+
+**Step 2: Build to verify no XML doc warnings**
+
+Run: `dotnet build`
+Expected: Clean build
+
+**Step 3: Commit**
+
+```
+docs: add XML documentation to all ClaimsPrincipal extension methods
+
+As a public NuGet package, all public methods need IntelliSense docs.
+```
+
+---
+
+### Task 6: Fix xUnit analyzer warnings in exception tests
+
+Exception tests use `Assert.True(x.Equals(y))` and `Assert.True(x == y)` instead of `Assert.Equal` / `Assert.Same`, producing poor failure messages.
+
+**Files:**
+- Modify: `AGDevX.Tests/Exceptions/AcquireTokenExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/ApplicationStartupExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/ClaimNotFoundExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/CodedApplicationExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/ExtensionMethodExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/ExtensionMethodParameterNullExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/MissingRequiredClaimExceptionTests.cs`
+- Modify: `AGDevX.Tests/Exceptions/NotAuthorizedExceptionTests.cs`
+
+**Step 1: Replace assertion patterns across all 8 files**
+
+Pattern replacements:
+- `Assert.True(new XException().Code.Equals(defaultCode))` -> `Assert.Equal(defaultCode, new XException().Code)`
+- `Assert.True(new XException("msg", code).Code.Equals(code))` -> `Assert.Equal(code, new XException("msg", code).Code)`
+- `Assert.True(new XException(message).Message.Equals(message))` -> `Assert.Equal(message, new XException(message).Message)`
+- `Assert.True(new XException(message, innerException).Message.Equals(message))` -> `Assert.Equal(message, new XException(message, innerException).Message)`
+- `Assert.True(new XException(message, innerException).InnerException == innerException)` -> `Assert.Same(innerException, new XException(message, innerException).InnerException)`
+- Similar patterns for the 3-arg constructor variants
+
+**Step 2: Build and run tests**
+
+Run: `dotnet build && dotnet test --verbosity normal`
+Expected: All tests PASS, analyzer warnings gone
+
+**Step 3: Commit**
+
+```
+test: use Assert.Equal/Assert.Same instead of Assert.True for value comparisons
+
+Fixes xUnit analyzer warnings and produces better failure messages.
+```
+
+---
+
+### Task 7: Add net8.0 multi-targeting
+
+Consumers on .NET 8 LTS cannot use the library. Add `net8.0` as a target.
+
+**Files:**
+- Modify: `AGDevX/AGDevX.csproj:4`
+- Modify: `AGDevX.Tests/AGDevX.Tests.csproj:4`
+
+**Step 1: Update main project to multi-target**
+
+In `AGDevX/AGDevX.csproj`, change:
+```xml
+<!-- FROM: -->
+<TargetFramework>net10.0</TargetFramework>
+<!-- TO: -->
+<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+```
+
+**Step 2: Update test project to multi-target**
+
+In `AGDevX.Tests/AGDevX.Tests.csproj`, change:
+```xml
+<!-- FROM: -->
+<TargetFramework>net10.0</TargetFramework>
+<!-- TO: -->
+<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+```
+
+**Step 3: Build and run tests on both targets**
+
+Run: `dotnet build && dotnet test --verbosity normal`
+Expected: Build succeeds for both TFMs, all tests pass on both
+
+**Step 4: Commit**
+
+```
+feat: add net8.0 multi-targeting
+
+Enables consumers on .NET 8 LTS to use the library alongside .NET 10.
+```
+
+---
+
+### Task 8: Enable push-to-main trigger in CI
+
+Merges to main are not validated by CI.
+
+**Files:**
+- Modify: `.github/workflows/build-test-create-nuget-package.yml:6-9`
+
+**Step 1: Uncomment push trigger for main**
+
+```yaml
+# FROM:
+on:
+  pull_request:
+  #push:
+  #  tags:
+  #    - 'v*'
+
+# TO:
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+```
+
+Note: Keep the tag-based push commented out (that's for NuGet publishing).
+
+**Step 2: Commit**
+
+```
+ci: enable CI on push to main
+
+Ensures merges to main are validated, not just pull requests.
+```
+
+---
+
+### Task 9: Document ClaimsPrincipal extensions in README
+
+The README's ClaimsPrincipal section is a one-line stub.
+
+**Files:**
+- Modify: `README.md:102-104`
+
+**Step 1: Expand the ClaimsPrincipal section**
+
+Replace the stub with a full listing of all Get/TryGet pairs, grouped by claim category. Follow the same format as other README sections (bullet list with method name and description).
+
+**Step 2: Remove the duplicate tech debt line at the bottom of the README**
+
+Line 123 (`- Document all ClaimsPrincipal extensions (there are many)`) can be removed since this task completes it.
+
+**Step 3: Commit**
+
+```
+docs: document all ClaimsPrincipal extension methods in README
+```
+
+---
+
+### Task 10: Clean up stale NOTES.md
+
+**Files:**
+- Modify: `.claude/NOTES.md`
+
+**Step 1: Remove stale items**
+
+- Remove the feature branch observation about `ag/NullIfNullOrWhiteSpace` (already merged)
+- Remove the README tech debt item about ClaimsPrincipal (completed in Task 9)
+- Remove the observation about "README tech debt item about unit tests may be outdated" (it is)
+- Keep only items that are still relevant (if any)
+
+**Step 2: Commit**
+
+```
+chore: clean up stale NOTES.md items
+```


### PR DESCRIPTION
## Summary

- **Bug fix:** `IsWhiteSpace`/`IsNotWhiteSpace` now use `char.IsWhiteSpace` instead of only checking for space characters
- **Bug fix:** Removed `[AllowNull]` from parameters that immediately throw on null — API contract now matches behavior
- **Docs:** Added XML documentation to all 76 public ClaimsPrincipal extension methods (was missing on 72 of them)
- **Docs:** Documented `TryGetAddress` JsonDocument disposal trade-off in remarks
- **Docs:** Fully documented all ClaimsPrincipal extensions in README (was a one-line stub)
- **Cleanup:** Removed unnecessary `$` string interpolation prefix from exception messages
- **Tests:** Replaced `Assert.True(x.Equals(y))` with `Assert.Equal`/`Assert.Same` across 8 exception test files
- **Feature:** Added `net8.0` multi-targeting so .NET 8 LTS consumers can use the library
- **CI:** Enabled CI on push to main; added .NET 8 SDK installation for multi-targeted test execution
- **Chore:** Cleaned up stale NOTES.md items

## Test plan
- [x] All 360 tests pass on net10.0
- [x] Build succeeds for both net8.0 and net10.0
- [ ] CI validates on all 3 OS matrices (ubuntu, windows, macOS)
- [ ] Verify net8.0 tests pass in CI (runtime not installed locally)