### PR TITLE
Quality and tooling improvements

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,6 +17,7 @@ A foundational C# NuGet package — extension methods, utilities, and helpers.
 - As a public NuGet package, consumers rely on IntelliSense documentation
 - Every public method, class, enum, and property must have XML docs
 
-### Zero external dependencies
-- This library depends only on the .NET runtime — no NuGet packages
-- Keep it that way unless there's a compelling reason to add one
+### Zero runtime dependencies
+- This library has no runtime NuGet dependencies — consumers get no transitive packages
+- Build-time tooling (SourceLink, analyzers) is acceptable via `PrivateAssets="All"`
+- Keep runtime dependencies at zero unless there's a compelling reason to add one

--- a/.github/workflows/build-test-create-nuget-package.yml
+++ b/.github/workflows/build-test-create-nuget-package.yml
@@ -44,7 +44,26 @@ jobs:
         run: dotnet build ${{ env.SOLUTION_PATH }} --configuration ${{ env.CONFIGURATION }} --no-restore
 
       - name: Run Unit Tests
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Check Code Coverage Threshold
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          COVERAGE_FILE=$(find ./coverage -name "coverage.cobertura.xml" | head -1)
+          if [ -z "$COVERAGE_FILE" ]; then
+            echo "::error::No coverage file found"
+            exit 1
+          fi
+          LINE_RATE=$(grep -oP 'line-rate="\K[^"]+' "$COVERAGE_FILE" | head -1)
+          COVERAGE_PCT=$(echo "$LINE_RATE * 100" | bc -l | xargs printf "%.1f")
+          echo "Line coverage: ${COVERAGE_PCT}%"
+          THRESHOLD=80
+          if (( $(echo "$COVERAGE_PCT < $THRESHOLD" | bc -l) )); then
+            echo "::error::Code coverage ${COVERAGE_PCT}% is below ${THRESHOLD}% threshold"
+            exit 1
+          fi
+          echo "Coverage ${COVERAGE_PCT}% meets ${THRESHOLD}% threshold"
 
       #- name: Get version
       #  id: version

--- a/AGDevX.Tests/AGDevX.Tests.csproj
+++ b/AGDevX.Tests/AGDevX.Tests.csproj
@@ -1,10 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-		<ImplicitUsings>disable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>

--- a/AGDevX.Tests/Exceptions/CodedArgumentNullExceptionTests.cs
+++ b/AGDevX.Tests/Exceptions/CodedArgumentNullExceptionTests.cs
@@ -1,0 +1,69 @@
+using System;
+using AGDevX.Exceptions;
+using Xunit;
+
+namespace AGDevX.Tests.Exceptions;
+
+public sealed class CodedArgumentNullExceptionTests
+{
+    public class When_throwing_a_CodedArgumentNullException
+    {
+        [Fact]
+        public void And_has_correct_default_code_then_assert_true()
+        {
+            //-- Arrange
+            var defaultCode = "CODED_ARGUMENT_NULL_EXCEPTION";
+
+            //-- Assert
+            Assert.Equal(defaultCode, new CodedArgumentNullException().Code);
+        }
+
+        [Fact]
+        public void And_has_correct_code_then_assert_true()
+        {
+            //-- Arrange
+            var code = "ex";
+
+            //-- Assert
+            Assert.Equal(code, new CodedArgumentNullException("arg", code).Code);
+        }
+
+        [Fact]
+        public void And_has_correct_argument_name_then_assert_true()
+        {
+            //-- Arrange
+            var argumentName = "testArgument";
+
+            //-- Assert
+            Assert.Equal(argumentName, new CodedArgumentNullException(argumentName).ParamName);
+        }
+
+        [Fact]
+        public void And_should_have_inner_exception_then_make_sure_it_has_inner_exception()
+        {
+            //-- Arrange
+            var message = "Test message";
+            var innerExceptionMessage = "Inner exception message";
+            var innerException = new Exception(innerExceptionMessage);
+
+            //-- Assert
+            Assert.Equal(message, new CodedArgumentNullException(message, innerException).Message);
+            Assert.Same(innerException, new CodedArgumentNullException(message, innerException).InnerException);
+        }
+
+        [Fact]
+        public void And_should_have_inner_exception_then_make_all_properties_are_correct()
+        {
+            //-- Arrange
+            var argumentName = "testArgument";
+            var code = "ex";
+            var innerExceptionMessage = "Inner exception message";
+            var innerException = new Exception(innerExceptionMessage);
+
+            //-- Assert
+            Assert.Equal(argumentName, new CodedArgumentNullException(argumentName, code, innerException).ParamName);
+            Assert.Equal(code, new CodedArgumentNullException(argumentName, code, innerException).Code);
+            Assert.Same(innerException, new CodedArgumentNullException(argumentName, code, innerException).InnerException);
+        }
+    }
+}

--- a/AGDevX.Tests/Exceptions/ExceptionDetailTests.cs
+++ b/AGDevX.Tests/Exceptions/ExceptionDetailTests.cs
@@ -149,5 +149,34 @@ public sealed class ExceptionDetailTests
                 }
             }
         }
+
+        public class And_called_on_a_plain_Exception
+        {
+            [Fact]
+            public void Then_return_exception_detail_with_provided_code()
+            {
+                //-- Arrange
+                var code = "CUSTOM_CODE";
+                var message = "Something went wrong";
+                var exception = new InvalidOperationException(message);
+
+                //-- Act
+                ExceptionDetail exceptionDetail;
+                try
+                {
+                    throw exception;
+                }
+                catch (Exception ex)
+                {
+                    exceptionDetail = ex.GetExceptionDetail(code);
+                }
+
+                //-- Assert
+                Assert.Equal(code, exceptionDetail.Code);
+                Assert.Equal(message, exceptionDetail.Message);
+                Assert.NotNull(exceptionDetail.StackFrames);
+                Assert.Null(exceptionDetail.InnerException);
+            }
+        }
     }
 }

--- a/AGDevX.Tests/Security/Auth0ClaimTypeTests.cs
+++ b/AGDevX.Tests/Security/Auth0ClaimTypeTests.cs
@@ -1,0 +1,22 @@
+using AGDevX.Enums;
+using AGDevX.Security;
+using Xunit;
+
+namespace AGDevX.Tests.Security;
+
+public sealed class Auth0ClaimTypeTests
+{
+    public class When_calling_StringValue
+    {
+        [Theory]
+        [InlineData(Auth0ClaimType.GrantType, "gty")]
+        public void Then_return_expected_string_value(Auth0ClaimType claimType, string expected)
+        {
+            //-- Act
+            var result = claimType.StringValue();
+
+            //-- Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/AGDevX.Tests/Security/CustomClaimTypeTests.cs
+++ b/AGDevX.Tests/Security/CustomClaimTypeTests.cs
@@ -1,0 +1,26 @@
+using AGDevX.Enums;
+using AGDevX.Security;
+using Xunit;
+
+namespace AGDevX.Tests.Security;
+
+public sealed class CustomClaimTypeTests
+{
+    public class When_calling_StringValue
+    {
+        [Theory]
+        [InlineData(CustomClaimType.RequestIp, "request_ip")]
+        [InlineData(CustomClaimType.AppMetadata, "app_metadata")]
+        [InlineData(CustomClaimType.CreatedAt, "created_at")]
+        [InlineData(CustomClaimType.UserId, "user_id")]
+        [InlineData(CustomClaimType.IsActive, "isActive")]
+        public void Then_return_expected_string_value(CustomClaimType claimType, string expected)
+        {
+            //-- Act
+            var result = claimType.StringValue();
+
+            //-- Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/AGDevX.Tests/Security/JwtClaimTypeTests.cs
+++ b/AGDevX.Tests/Security/JwtClaimTypeTests.cs
@@ -1,0 +1,58 @@
+using AGDevX.Enums;
+using AGDevX.Security;
+using Xunit;
+
+namespace AGDevX.Tests.Security;
+
+public sealed class JwtClaimTypeTests
+{
+    public class When_calling_StringValue
+    {
+        [Theory]
+        [InlineData(JwtClaimType.Issuer, "iss")]
+        [InlineData(JwtClaimType.Subject, "sub")]
+        [InlineData(JwtClaimType.Audience, "aud")]
+        [InlineData(JwtClaimType.Expiration, "exp")]
+        [InlineData(JwtClaimType.NotBefore, "nbf")]
+        [InlineData(JwtClaimType.IssuedAt, "iat")]
+        [InlineData(JwtClaimType.JwtId, "jti")]
+        [InlineData(JwtClaimType.Name, "name")]
+        [InlineData(JwtClaimType.GivenName, "given_name")]
+        [InlineData(JwtClaimType.FamilyName, "family_name")]
+        [InlineData(JwtClaimType.MiddleName, "middle_name")]
+        [InlineData(JwtClaimType.Nickname, "nickname")]
+        [InlineData(JwtClaimType.PreferredUsername, "preferred_username")]
+        [InlineData(JwtClaimType.Profile, "profile")]
+        [InlineData(JwtClaimType.Picture, "picture")]
+        [InlineData(JwtClaimType.Website, "website")]
+        [InlineData(JwtClaimType.Email, "email")]
+        [InlineData(JwtClaimType.EmailVerified, "email_verified")]
+        [InlineData(JwtClaimType.Gender, "gender")]
+        [InlineData(JwtClaimType.Birthdate, "birthdate")]
+        [InlineData(JwtClaimType.ZoneInfo, "zoneinfo")]
+        [InlineData(JwtClaimType.Locale, "locale")]
+        [InlineData(JwtClaimType.PhoneNumber, "phone_number")]
+        [InlineData(JwtClaimType.PhoneNumberVerified, "phone_number_verified")]
+        [InlineData(JwtClaimType.Address, "address")]
+        [InlineData(JwtClaimType.UpdatedAt, "updated_at")]
+        [InlineData(JwtClaimType.AuthorizedParty, "azp")]
+        [InlineData(JwtClaimType.Nonce, "nonce")]
+        [InlineData(JwtClaimType.AuthTime, "auth_time")]
+        [InlineData(JwtClaimType.AccessTokenHash, "at_hash")]
+        [InlineData(JwtClaimType.CodeHash, "c_hash")]
+        [InlineData(JwtClaimType.AuthenticationContextClassReference, "acr")]
+        [InlineData(JwtClaimType.AuthenticationMethodsReference, "amr")]
+        [InlineData(JwtClaimType.SessionId, "sid")]
+        [InlineData(JwtClaimType.Scope, "scope")]
+        [InlineData(JwtClaimType.ClientId, "client_id")]
+        [InlineData(JwtClaimType.Roles, "roles")]
+        public void Then_return_expected_string_value(JwtClaimType claimType, string expected)
+        {
+            //-- Act
+            var result = claimType.StringValue();
+
+            //-- Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/AGDevX/AGDevX.csproj
+++ b/AGDevX/AGDevX.csproj
@@ -32,6 +32,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/AGDevX/AGDevX.csproj
+++ b/AGDevX/AGDevX.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-		<ImplicitUsings>disable</ImplicitUsings>
-		<Nullable>enable</Nullable>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<AnalysisLevel>latest-recommended</AnalysisLevel>
 		<!--

--- a/AGDevX/AGDevX.csproj
+++ b/AGDevX/AGDevX.csproj
@@ -31,6 +31,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <None Include="..\Icon-NuGet.png">
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>

--- a/AGDevX/Enums/EnumStringValueAttribute.cs
+++ b/AGDevX/Enums/EnumStringValueAttribute.cs
@@ -10,8 +10,15 @@ namespace AGDevX.Enums;
 [AttributeUsage(AttributeTargets.Field)]
 public sealed class EnumStringValueAttribute : Attribute
 {
+    /// <summary>
+    /// The string value associated with the decorated enum field.
+    /// </summary>
     public string Value { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnumStringValueAttribute"/> class with the specified string value.
+    /// </summary>
+    /// <param name="value">The string value to associate with the decorated enum field.</param>
     public EnumStringValueAttribute(string value)
     {
         Value = value;

--- a/AGDevX/Exceptions/AcquireTokenException.cs
+++ b/AGDevX/Exceptions/AcquireTokenException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class AcquireTokenException : CodedApplicationException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "ACQUIRE_TOKEN_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AcquireTokenException"/> class with the default code.
+    /// </summary>
     public AcquireTokenException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AcquireTokenException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public AcquireTokenException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AcquireTokenException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public AcquireTokenException(string message, string code) : base(message, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AcquireTokenException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public AcquireTokenException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AcquireTokenException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public AcquireTokenException(string message, string code, Exception innerException) : base(message, code, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/ApplicationStartupException.cs
+++ b/AGDevX/Exceptions/ApplicationStartupException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class ApplicationStartupException : CodedApplicationException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "APPLICATION_STARTUP_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationStartupException"/> class with the default code.
+    /// </summary>
     public ApplicationStartupException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationStartupException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public ApplicationStartupException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationStartupException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public ApplicationStartupException(string message, string code) : base(message, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationStartupException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ApplicationStartupException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApplicationStartupException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ApplicationStartupException(string message, string code, Exception innerException) : base(message, code, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/ClaimNotFoundException.cs
+++ b/AGDevX/Exceptions/ClaimNotFoundException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class ClaimNotFoundException : CodedApplicationException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "CLAIM_NOT_FOUND_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaimNotFoundException"/> class with the default code.
+    /// </summary>
     public ClaimNotFoundException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaimNotFoundException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public ClaimNotFoundException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaimNotFoundException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public ClaimNotFoundException(string message, string code) : base(message, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaimNotFoundException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ClaimNotFoundException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClaimNotFoundException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ClaimNotFoundException(string message, string code, Exception innerException) : base(message, code, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/CodedApplicationException.cs
+++ b/AGDevX/Exceptions/CodedApplicationException.cs
@@ -8,25 +8,51 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public class CodedApplicationException : ApplicationException
 {
+    /// <summary>
+    /// A code providing additional context into the origin of the exception.
+    /// </summary>
     public virtual string Code { get; set; } = "CODED_APPLICATION_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedApplicationException"/> class with the default code.
+    /// </summary>
     public CodedApplicationException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public CodedApplicationException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public CodedApplicationException(string message, string code) : base(message)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public CodedApplicationException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public CodedApplicationException(string message, string code, Exception innerException) : base(message, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/CodedArgumentNullException.cs
+++ b/AGDevX/Exceptions/CodedArgumentNullException.cs
@@ -8,25 +8,51 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public class CodedArgumentNullException : ArgumentNullException
 {
+    /// <summary>
+    /// A code providing additional context into the origin of the exception.
+    /// </summary>
     public virtual string Code { get; set; } = "CODED_ARGUMENT_NULL_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with the default code.
+    /// </summary>
     public CodedArgumentNullException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified argument name.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument that caused the exception.</param>
     public CodedArgumentNullException(string argumentName) : base(argumentName)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified argument name and code.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument that caused the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public CodedArgumentNullException(string argumentName, string code) : base(argumentName)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public CodedArgumentNullException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified argument name, code, and inner exception.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument that caused the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public CodedArgumentNullException(string argumentName, string code, Exception innerException) : base(argumentName, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/CodedArgumentNullException.cs
+++ b/AGDevX/Exceptions/CodedArgumentNullException.cs
@@ -8,10 +8,19 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public class CodedArgumentNullException : ArgumentNullException
 {
+    private readonly string? _argumentName;
+
     /// <summary>
     /// A code providing additional context into the origin of the exception.
     /// </summary>
     public virtual string Code { get; set; } = "CODED_ARGUMENT_NULL_EXCEPTION";
+
+    /// <summary>
+    /// Gets the name of the argument that caused the exception.
+    /// Overridden to preserve the argument name when constructed with an inner exception,
+    /// because ArgumentNullException lacks a constructor accepting both paramName and innerException.
+    /// </summary>
+    public override string? ParamName => _argumentName ?? base.ParamName;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with the default code.
@@ -55,6 +64,7 @@ public class CodedArgumentNullException : ArgumentNullException
     /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public CodedArgumentNullException(string argumentName, string code, Exception innerException) : base(argumentName, innerException)
     {
+        _argumentName = argumentName;
         Code = code;
     }
 }

--- a/AGDevX/Exceptions/ExceptionDetail.cs
+++ b/AGDevX/Exceptions/ExceptionDetail.cs
@@ -14,18 +14,59 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class ExceptionDetail
 {
+    /// <summary>
+    /// A code identifying the type or origin of the exception.
+    /// </summary>
     public required string Code { get; set; }
+
+    /// <summary>
+    /// The exception error message.
+    /// </summary>
     public required string Message { get; set; }
+
+    /// <summary>
+    /// The parsed stack frames from the exception, or <see langword="null"/> if stack frames were not included.
+    /// </summary>
     public IEnumerable<StackFrameModel>? StackFrames { get; set; }
+
+    /// <summary>
+    /// The inner exception detail, or <see langword="null"/> if there is no inner exception.
+    /// </summary>
     public ExceptionDetail? InnerException { get; set; }
 
+    /// <summary>
+    /// Structured representation of a single stack frame.
+    /// </summary>
     public sealed class StackFrameModel
     {
+        /// <summary>
+        /// The line number in the source code file where the frame originated.
+        /// </summary>
         public int LineNumber { get; set; }
+
+        /// <summary>
+        /// The method signature where the frame originated.
+        /// </summary>
         public string? Method { get; set; }
+
+        /// <summary>
+        /// The fully qualified class name where the frame originated.
+        /// </summary>
         public string? Class { get; set; }
+
+        /// <summary>
+        /// The full name of the assembly containing the frame.
+        /// </summary>
         public string? AssemblyName { get; set; }
+
+        /// <summary>
+        /// The file path of the assembly containing the frame.
+        /// </summary>
         public string? AssemblyFile { get; set; }
+
+        /// <summary>
+        /// The source code file path where the frame originated.
+        /// </summary>
         public string? CodeFile { get; set; }
     }
 }

--- a/AGDevX/Exceptions/ExtensionMethodException.cs
+++ b/AGDevX/Exceptions/ExtensionMethodException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class ExtensionMethodException : CodedApplicationException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "EXTENSION_METHOD_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodException"/> class with the default code.
+    /// </summary>
     public ExtensionMethodException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public ExtensionMethodException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public ExtensionMethodException(string message, string code) : base(message, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ExtensionMethodException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ExtensionMethodException(string message, string code, Exception innerException) : base(message, code, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/ExtensionMethodParameterNullException.cs
+++ b/AGDevX/Exceptions/ExtensionMethodParameterNullException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class ExtensionMethodParameterNullException : CodedArgumentNullException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "EXTENSION_METHOD_PARAMETER_NULL_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodParameterNullException"/> class with the default code.
+    /// </summary>
     public ExtensionMethodParameterNullException() : base()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodParameterNullException"/> class with a specified argument name.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument that caused the exception.</param>
     public ExtensionMethodParameterNullException(string argumentName) : base(argumentName)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodParameterNullException"/> class with a specified argument name and code.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument that caused the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public ExtensionMethodParameterNullException(string argumentName, string code) : base(argumentName, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodParameterNullException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ExtensionMethodParameterNullException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtensionMethodParameterNullException"/> class with a specified argument name, code, and inner exception.
+    /// </summary>
+    /// <param name="argumentName">The name of the argument that caused the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public ExtensionMethodParameterNullException(string argumentName, string code, Exception innerException) : base(argumentName, code, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/MissingRequiredClaimException.cs
+++ b/AGDevX/Exceptions/MissingRequiredClaimException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class MissingRequiredClaimException : CodedApplicationException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "MISSING_REQUIRED_CLAIM_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredClaimException"/> class with the default code.
+    /// </summary>
     public MissingRequiredClaimException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredClaimException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public MissingRequiredClaimException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredClaimException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public MissingRequiredClaimException(string message, string code) : base(message, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredClaimException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public MissingRequiredClaimException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MissingRequiredClaimException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public MissingRequiredClaimException(string message, string code, Exception innerException) : base(message, code, innerException)
     {
         Code = code;

--- a/AGDevX/Exceptions/NotAuthorizedException.cs
+++ b/AGDevX/Exceptions/NotAuthorizedException.cs
@@ -7,25 +7,49 @@ namespace AGDevX.Exceptions;
 /// </summary>
 public sealed class NotAuthorizedException : CodedApplicationException
 {
+    /// <inheritdoc />
     public override string Code { get; set; } = "NOT_AUTHORIZED_EXCEPTION";
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotAuthorizedException"/> class with the default code.
+    /// </summary>
     public NotAuthorizedException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotAuthorizedException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
     public NotAuthorizedException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotAuthorizedException"/> class with a specified error message and code.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
     public NotAuthorizedException(string message, string code) : base(message, code)
     {
         Code = code;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotAuthorizedException"/> class with a specified error message and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public NotAuthorizedException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotAuthorizedException"/> class with a specified error message, code, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="code">A code providing additional context into the origin of the exception.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     public NotAuthorizedException(string message, string code, Exception innerException) : base(message, code, innerException)
     {
         Code = code;

--- a/AGDevX/PublicAPI.Shipped.txt
+++ b/AGDevX/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/AGDevX/PublicAPI.Unshipped.txt
+++ b/AGDevX/PublicAPI.Unshipped.txt
@@ -145,6 +145,7 @@ override AGDevX.Exceptions.ApplicationStartupException.Code.get -> string!
 override AGDevX.Exceptions.ApplicationStartupException.Code.set -> void
 override AGDevX.Exceptions.ClaimNotFoundException.Code.get -> string!
 override AGDevX.Exceptions.ClaimNotFoundException.Code.set -> void
+override AGDevX.Exceptions.CodedArgumentNullException.ParamName.get -> string?
 override AGDevX.Exceptions.ExtensionMethodException.Code.get -> string!
 override AGDevX.Exceptions.ExtensionMethodException.Code.set -> void
 override AGDevX.Exceptions.ExtensionMethodParameterNullException.Code.get -> string!

--- a/AGDevX/PublicAPI.Unshipped.txt
+++ b/AGDevX/PublicAPI.Unshipped.txt
@@ -1,0 +1,274 @@
+#nullable enable
+AGDevX.Assemblies.AssemblyExtensions
+AGDevX.Assemblies.AssemblyUtility
+AGDevX.Attributes.AttributeExtensions
+AGDevX.DateTimes.DateTimeExtensions
+AGDevX.Enums.EnumExtensions
+AGDevX.Enums.EnumStringValueAttribute
+AGDevX.Enums.EnumStringValueAttribute.EnumStringValueAttribute(string! value) -> void
+AGDevX.Enums.EnumStringValueAttribute.Value.get -> string!
+AGDevX.Enums.EnumStringValueAttributeExtensions
+AGDevX.Exceptions.AcquireTokenException
+AGDevX.Exceptions.AcquireTokenException.AcquireTokenException() -> void
+AGDevX.Exceptions.AcquireTokenException.AcquireTokenException(string! message) -> void
+AGDevX.Exceptions.AcquireTokenException.AcquireTokenException(string! message, string! code) -> void
+AGDevX.Exceptions.AcquireTokenException.AcquireTokenException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.AcquireTokenException.AcquireTokenException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.ApplicationStartupException
+AGDevX.Exceptions.ApplicationStartupException.ApplicationStartupException() -> void
+AGDevX.Exceptions.ApplicationStartupException.ApplicationStartupException(string! message) -> void
+AGDevX.Exceptions.ApplicationStartupException.ApplicationStartupException(string! message, string! code) -> void
+AGDevX.Exceptions.ApplicationStartupException.ApplicationStartupException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.ApplicationStartupException.ApplicationStartupException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.ClaimNotFoundException
+AGDevX.Exceptions.ClaimNotFoundException.ClaimNotFoundException() -> void
+AGDevX.Exceptions.ClaimNotFoundException.ClaimNotFoundException(string! message) -> void
+AGDevX.Exceptions.ClaimNotFoundException.ClaimNotFoundException(string! message, string! code) -> void
+AGDevX.Exceptions.ClaimNotFoundException.ClaimNotFoundException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.ClaimNotFoundException.ClaimNotFoundException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.CodedApplicationException
+AGDevX.Exceptions.CodedApplicationException.CodedApplicationException() -> void
+AGDevX.Exceptions.CodedApplicationException.CodedApplicationException(string! message) -> void
+AGDevX.Exceptions.CodedApplicationException.CodedApplicationException(string! message, string! code) -> void
+AGDevX.Exceptions.CodedApplicationException.CodedApplicationException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.CodedApplicationException.CodedApplicationException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.CodedArgumentNullException
+AGDevX.Exceptions.CodedArgumentNullException.CodedArgumentNullException() -> void
+AGDevX.Exceptions.CodedArgumentNullException.CodedArgumentNullException(string! argumentName) -> void
+AGDevX.Exceptions.CodedArgumentNullException.CodedArgumentNullException(string! argumentName, string! code) -> void
+AGDevX.Exceptions.CodedArgumentNullException.CodedArgumentNullException(string! argumentName, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.CodedArgumentNullException.CodedArgumentNullException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.ExceptionDetail
+AGDevX.Exceptions.ExceptionDetail.Code.get -> string!
+AGDevX.Exceptions.ExceptionDetail.Code.set -> void
+AGDevX.Exceptions.ExceptionDetail.ExceptionDetail() -> void
+AGDevX.Exceptions.ExceptionDetail.InnerException.get -> AGDevX.Exceptions.ExceptionDetail?
+AGDevX.Exceptions.ExceptionDetail.InnerException.set -> void
+AGDevX.Exceptions.ExceptionDetail.Message.get -> string!
+AGDevX.Exceptions.ExceptionDetail.Message.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.AssemblyFile.get -> string?
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.AssemblyFile.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.AssemblyName.get -> string?
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.AssemblyName.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.Class.get -> string?
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.Class.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.CodeFile.get -> string?
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.CodeFile.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.LineNumber.get -> int
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.LineNumber.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.Method.get -> string?
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.Method.set -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrameModel.StackFrameModel() -> void
+AGDevX.Exceptions.ExceptionDetail.StackFrames.get -> System.Collections.Generic.IEnumerable<AGDevX.Exceptions.ExceptionDetail.StackFrameModel!>?
+AGDevX.Exceptions.ExceptionDetail.StackFrames.set -> void
+AGDevX.Exceptions.ExceptionDetailExtensions
+AGDevX.Exceptions.ExtensionMethodException
+AGDevX.Exceptions.ExtensionMethodException.ExtensionMethodException() -> void
+AGDevX.Exceptions.ExtensionMethodException.ExtensionMethodException(string! message) -> void
+AGDevX.Exceptions.ExtensionMethodException.ExtensionMethodException(string! message, string! code) -> void
+AGDevX.Exceptions.ExtensionMethodException.ExtensionMethodException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.ExtensionMethodException.ExtensionMethodException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.ExtensionMethodParameterNullException
+AGDevX.Exceptions.ExtensionMethodParameterNullException.ExtensionMethodParameterNullException() -> void
+AGDevX.Exceptions.ExtensionMethodParameterNullException.ExtensionMethodParameterNullException(string! argumentName) -> void
+AGDevX.Exceptions.ExtensionMethodParameterNullException.ExtensionMethodParameterNullException(string! argumentName, string! code) -> void
+AGDevX.Exceptions.ExtensionMethodParameterNullException.ExtensionMethodParameterNullException(string! argumentName, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.ExtensionMethodParameterNullException.ExtensionMethodParameterNullException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.MissingRequiredClaimException
+AGDevX.Exceptions.MissingRequiredClaimException.MissingRequiredClaimException() -> void
+AGDevX.Exceptions.MissingRequiredClaimException.MissingRequiredClaimException(string! message) -> void
+AGDevX.Exceptions.MissingRequiredClaimException.MissingRequiredClaimException(string! message, string! code) -> void
+AGDevX.Exceptions.MissingRequiredClaimException.MissingRequiredClaimException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.MissingRequiredClaimException.MissingRequiredClaimException(string! message, System.Exception! innerException) -> void
+AGDevX.Exceptions.NotAuthorizedException
+AGDevX.Exceptions.NotAuthorizedException.NotAuthorizedException() -> void
+AGDevX.Exceptions.NotAuthorizedException.NotAuthorizedException(string! message) -> void
+AGDevX.Exceptions.NotAuthorizedException.NotAuthorizedException(string! message, string! code) -> void
+AGDevX.Exceptions.NotAuthorizedException.NotAuthorizedException(string! message, string! code, System.Exception! innerException) -> void
+AGDevX.Exceptions.NotAuthorizedException.NotAuthorizedException(string! message, System.Exception! innerException) -> void
+AGDevX.Guids.GuidExtensions
+AGDevX.IEnumerables.DictionaryExtensions
+AGDevX.IEnumerables.IEnumerableExtensions
+AGDevX.Objects.ObjectExtensions
+AGDevX.Security.Auth0ClaimType
+AGDevX.Security.Auth0ClaimType.GrantType = 1 -> AGDevX.Security.Auth0ClaimType
+AGDevX.Security.ClaimsPrincipalExtensions
+AGDevX.Security.CustomClaimType
+AGDevX.Security.CustomClaimType.AppMetadata = 2 -> AGDevX.Security.CustomClaimType
+AGDevX.Security.CustomClaimType.CreatedAt = 3 -> AGDevX.Security.CustomClaimType
+AGDevX.Security.CustomClaimType.IsActive = 5 -> AGDevX.Security.CustomClaimType
+AGDevX.Security.CustomClaimType.RequestIp = 1 -> AGDevX.Security.CustomClaimType
+AGDevX.Security.CustomClaimType.UserId = 4 -> AGDevX.Security.CustomClaimType
+AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.AccessTokenHash = 30 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Address = 25 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Audience = 3 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.AuthenticationContextClassReference = 32 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.AuthenticationMethodsReference = 33 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.AuthorizedParty = 27 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.AuthTime = 29 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Birthdate = 20 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.ClientId = 36 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.CodeHash = 31 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Email = 17 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.EmailVerified = 18 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Expiration = 4 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.FamilyName = 10 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Gender = 19 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.GivenName = 9 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.IssuedAt = 6 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Issuer = 1 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.JwtId = 7 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Locale = 22 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.MiddleName = 11 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Name = 8 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Nickname = 12 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Nonce = 28 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.NotBefore = 5 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.PhoneNumber = 23 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.PhoneNumberVerified = 24 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Picture = 15 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.PreferredUsername = 13 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Profile = 14 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Roles = 37 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Scope = 35 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.SessionId = 34 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Subject = 2 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.UpdatedAt = 26 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.Website = 16 -> AGDevX.Security.JwtClaimType
+AGDevX.Security.JwtClaimType.ZoneInfo = 21 -> AGDevX.Security.JwtClaimType
+AGDevX.Strings.StringExtensions
+override AGDevX.Exceptions.AcquireTokenException.Code.get -> string!
+override AGDevX.Exceptions.AcquireTokenException.Code.set -> void
+override AGDevX.Exceptions.ApplicationStartupException.Code.get -> string!
+override AGDevX.Exceptions.ApplicationStartupException.Code.set -> void
+override AGDevX.Exceptions.ClaimNotFoundException.Code.get -> string!
+override AGDevX.Exceptions.ClaimNotFoundException.Code.set -> void
+override AGDevX.Exceptions.ExtensionMethodException.Code.get -> string!
+override AGDevX.Exceptions.ExtensionMethodException.Code.set -> void
+override AGDevX.Exceptions.ExtensionMethodParameterNullException.Code.get -> string!
+override AGDevX.Exceptions.ExtensionMethodParameterNullException.Code.set -> void
+override AGDevX.Exceptions.MissingRequiredClaimException.Code.get -> string!
+override AGDevX.Exceptions.MissingRequiredClaimException.Code.set -> void
+override AGDevX.Exceptions.NotAuthorizedException.Code.get -> string!
+override AGDevX.Exceptions.NotAuthorizedException.Code.set -> void
+static AGDevX.Assemblies.AssemblyExtensions.FullNameStartsWithPrefix(this System.Reflection.Assembly! assembly, string! prefix) -> bool
+static AGDevX.Assemblies.AssemblyExtensions.FullNameStartsWithPrefixes(this System.Reflection.Assembly! assembly, System.Collections.Generic.IEnumerable<string!>! prefixes) -> bool
+static AGDevX.Assemblies.AssemblyUtility.AssemblyNameStartsWithAnyPrefix(string! assemblyFullName, System.Collections.Generic.IEnumerable<string!>! assemblyPrefixes) -> bool
+static AGDevX.Assemblies.AssemblyUtility.GetAssemblies(System.Reflection.Assembly? parent, System.Collections.Generic.IEnumerable<string!>! assemblyPrefixes) -> System.Collections.Generic.List<System.Reflection.Assembly!>!
+static AGDevX.Attributes.AttributeExtensions.GetDescription<T>(this T obj, bool searchInheritanceChain = true) -> string?
+static AGDevX.DateTimes.DateTimeExtensions.SpecifyKind(this System.DateTime value, System.DateTimeKind kind) -> System.DateTime
+static AGDevX.Enums.EnumExtensions.IsOneOf(this System.Enum! enumeration, params System.Enum![]! enums) -> bool
+static AGDevX.Enums.EnumStringValueAttributeExtensions.StringValue(this System.Enum! value) -> string!
+static AGDevX.Exceptions.ExceptionDetailExtensions.GetExceptionDetail(this AGDevX.Exceptions.CodedApplicationException! codedEx, bool includeStackFrames = true, bool filterStackFrames = false, System.Collections.Generic.IEnumerable<string!>? assemblyPrefixes = null) -> AGDevX.Exceptions.ExceptionDetail!
+static AGDevX.Exceptions.ExceptionDetailExtensions.GetExceptionDetail(this System.Exception! ex, string! code, bool includeStackFrames = true, bool filterStackFrames = false, System.Collections.Generic.IEnumerable<string!>? assemblyPrefixes = null) -> AGDevX.Exceptions.ExceptionDetail!
+static AGDevX.Guids.GuidExtensions.IsEmpty(this System.Guid guid) -> bool
+static AGDevX.Guids.GuidExtensions.IsNotEmpty(this System.Guid guid) -> bool
+static AGDevX.Guids.GuidExtensions.IsNotNull(this System.Guid? guid) -> bool
+static AGDevX.Guids.GuidExtensions.IsNotNullNorEmpty(this System.Guid? guid) -> bool
+static AGDevX.Guids.GuidExtensions.IsNull(this System.Guid? guid) -> bool
+static AGDevX.Guids.GuidExtensions.IsNullOrEmpty(this System.Guid? guid) -> bool
+static AGDevX.IEnumerables.DictionaryExtensions.Concatenate<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue>! dictionary1, System.Collections.Generic.Dictionary<TKey, TValue>! dictionary2) -> System.Collections.Generic.Dictionary<TKey, TValue>!
+static AGDevX.IEnumerables.DictionaryExtensions.ReverseKeysAndValues<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue>! dictionary) -> System.Collections.Generic.Dictionary<TValue, TKey>!
+static AGDevX.IEnumerables.IEnumerableExtensions.AnySafe<T>(this System.Collections.Generic.IEnumerable<T>? enumerable) -> bool
+static AGDevX.IEnumerables.IEnumerableExtensions.ContainsIgnoreCase(this System.Collections.Generic.IEnumerable<string?>! strings, string! str, System.StringComparer? stringComparer = null) -> bool
+static AGDevX.IEnumerables.IEnumerableExtensions.HasCommonStringElement(this System.Collections.Generic.IEnumerable<string!>! enumerable1, System.Collections.Generic.IEnumerable<string!>! enumerable2, System.StringComparer? stringComparer = null) -> bool
+static AGDevX.IEnumerables.IEnumerableExtensions.IsNullOrEmpty<T>(this System.Collections.Generic.IEnumerable<T>? enumerable) -> bool
+static AGDevX.IEnumerables.IEnumerableExtensions.ToDataTable<T>(this System.Collections.Generic.IEnumerable<T>! enumerable, string! columnName = "Id") -> System.Data.DataTable!
+static AGDevX.Objects.ObjectExtensions.IsNotNull(this object? obj) -> bool
+static AGDevX.Objects.ObjectExtensions.IsNull(this object? obj) -> bool
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAccessTokenHash(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAddress(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Text.Json.JsonElement
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAudiences(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Collections.Generic.IReadOnlyList<string!>!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAuthenticationContextClassReference(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAuthenticationMethodsReference(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAuthorizedParty(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetAuthTime(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int
+static AGDevX.Security.ClaimsPrincipalExtensions.GetBirthdate(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.DateTime
+static AGDevX.Security.ClaimsPrincipalExtensions.GetClientId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetCodeHash(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetEmail(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetEmailVerified(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> bool
+static AGDevX.Security.ClaimsPrincipalExtensions.GetExpiration(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int
+static AGDevX.Security.ClaimsPrincipalExtensions.GetExternalId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetFamilyName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetGender(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetGivenName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetGrantType(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetIsActive(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> bool
+static AGDevX.Security.ClaimsPrincipalExtensions.GetIssuedAt(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int
+static AGDevX.Security.ClaimsPrincipalExtensions.GetIssuer(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetJwtId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetLocale(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetMiddleName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetNickname(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetNonce(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetNotBefore(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int
+static AGDevX.Security.ClaimsPrincipalExtensions.GetPhoneNumber(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetPhoneNumberVerified(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> bool
+static AGDevX.Security.ClaimsPrincipalExtensions.GetPicture(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetPreferredUsername(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetProfile(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetRoles(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Collections.Generic.IReadOnlyList<string!>!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetScopes(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Collections.Generic.IReadOnlyList<string!>!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetSessionId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetSubject(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetUpdatedAt(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int
+static AGDevX.Security.ClaimsPrincipalExtensions.GetWebsite(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.GetZoneInfo(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string!
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAccessTokenHash(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAddress(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Text.Json.JsonElement?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAudiences(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Collections.Generic.IReadOnlyList<string!>?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAuthenticationContextClassReference(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAuthenticationMethodsReference(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAuthorizedParty(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetAuthTime(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetBirthdate(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.DateTime?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetClientId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetCodeHash(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetEmail(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetEmailVerified(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> bool?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetExpiration(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetExternalId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetFamilyName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetGender(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetGivenName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetGrantType(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetIsActive(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> bool?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetIssuedAt(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetIssuer(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetJwtId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetLocale(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetMiddleName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetName(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetNickname(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetNonce(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetNotBefore(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetPhoneNumber(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetPhoneNumberVerified(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> bool?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetPicture(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetPreferredUsername(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetProfile(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetRoles(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Collections.Generic.IReadOnlyList<string!>?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetScopes(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> System.Collections.Generic.IReadOnlyList<string!>?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetSessionId(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetSubject(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetUpdatedAt(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> int?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetWebsite(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Security.ClaimsPrincipalExtensions.TryGetZoneInfo(this System.Security.Claims.ClaimsPrincipal! claimsPrincipal) -> string?
+static AGDevX.Strings.StringExtensions.ContainsIgnoreCase(this string! string1, string! string2, System.StringComparison stringComparison = System.StringComparison.OrdinalIgnoreCase) -> bool
+static AGDevX.Strings.StringExtensions.EqualsIgnoreCase(this string! string1, string! string2, System.StringComparison stringComparison = System.StringComparison.OrdinalIgnoreCase) -> bool
+static AGDevX.Strings.StringExtensions.IsEmpty(this string! str) -> bool
+static AGDevX.Strings.StringExtensions.IsNotEmpty(this string! str) -> bool
+static AGDevX.Strings.StringExtensions.IsNotNullNorWhiteSpace(this string! str) -> bool
+static AGDevX.Strings.StringExtensions.IsNotWhiteSpace(this string! str) -> bool
+static AGDevX.Strings.StringExtensions.IsNullOrWhiteSpace(this string! str) -> bool
+static AGDevX.Strings.StringExtensions.IsWhiteSpace(this string! str) -> bool
+static AGDevX.Strings.StringExtensions.NullIfNullOrWhiteSpace(this string? str) -> string?
+static AGDevX.Strings.StringExtensions.StartsWithIgnoreCase(this string! string1, string! string2, System.StringComparison stringComparison = System.StringComparison.OrdinalIgnoreCase) -> bool
+virtual AGDevX.Exceptions.CodedApplicationException.Code.get -> string!
+virtual AGDevX.Exceptions.CodedApplicationException.Code.set -> void
+virtual AGDevX.Exceptions.CodedArgumentNullException.Code.get -> string!
+virtual AGDevX.Exceptions.CodedArgumentNullException.Code.set -> void

--- a/AGDevX/Security/ClaimsPrincipalExtensions.cs
+++ b/AGDevX/Security/ClaimsPrincipalExtensions.cs
@@ -62,18 +62,18 @@ public static class ClaimsPrincipalExtensions
     #region Audience
 
     /// <summary>
-    /// Returns the Audience claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// Returns the Audience claim values as a read-only list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
     /// </summary>
-    public static List<string> GetAudiences(this ClaimsPrincipal claimsPrincipal)
+    public static IReadOnlyList<string> GetAudiences(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetAudiences()
                     ?? throw new ClaimNotFoundException("An Audience claim was not found");
     }
 
     /// <summary>
-    /// Returns the Audience claim values as a list, or <see langword="null"/> if the claim is missing.
+    /// Returns the Audience claim values as a read-only list, or <see langword="null"/> if the claim is missing.
     /// </summary>
-    public static List<string>? TryGetAudiences(this ClaimsPrincipal claimsPrincipal)
+    public static IReadOnlyList<string>? TryGetAudiences(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.GetClaimValues<string>(JwtClaimType.Audience.StringValue());
     }
@@ -771,18 +771,18 @@ public static class ClaimsPrincipalExtensions
     #region Scope
 
     /// <summary>
-    /// Returns the Scope claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// Returns the Scope claim values as a read-only list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
     /// </summary>
-    public static List<string> GetScopes(this ClaimsPrincipal claimsPrincipal)
+    public static IReadOnlyList<string> GetScopes(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetScopes()
                     ?? throw new ClaimNotFoundException("A Scope claim was not found");
     }
 
     /// <summary>
-    /// Returns the Scope claim values as a list, or <see langword="null"/> if the claim is missing.
+    /// Returns the Scope claim values as a read-only list, or <see langword="null"/> if the claim is missing.
     /// </summary>
-    public static List<string>? TryGetScopes(this ClaimsPrincipal claimsPrincipal)
+    public static IReadOnlyList<string>? TryGetScopes(this ClaimsPrincipal claimsPrincipal)
     {
         var scopeStr = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Scope.StringValue());
         return scopeStr?.Split(' ').ToList();
@@ -814,18 +814,18 @@ public static class ClaimsPrincipalExtensions
     #region Roles
 
     /// <summary>
-    /// Returns the Roles claim values as a list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
+    /// Returns the Roles claim values as a read-only list. Throws <see cref="ClaimNotFoundException"/> if the claim is missing.
     /// </summary>
-    public static List<string> GetRoles(this ClaimsPrincipal claimsPrincipal)
+    public static IReadOnlyList<string> GetRoles(this ClaimsPrincipal claimsPrincipal)
     {
         return claimsPrincipal.TryGetRoles()
                     ?? throw new ClaimNotFoundException("A Roles claim was not found");
     }
 
     /// <summary>
-    /// Returns the Roles claim values as a list, or <see langword="null"/> if the claim is missing.
+    /// Returns the Roles claim values as a read-only list, or <see langword="null"/> if the claim is missing.
     /// </summary>
-    public static List<string>? TryGetRoles(this ClaimsPrincipal claimsPrincipal)
+    public static IReadOnlyList<string>? TryGetRoles(this ClaimsPrincipal claimsPrincipal)
     {
         var rolesStr = claimsPrincipal.GetClaimValue<string>(JwtClaimType.Roles.StringValue());
         return rolesStr?.Split(' ').ToList();

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AGDevX .NET
 
+[![Build](https://github.com/agdevx/AGDevX.NET/actions/workflows/build-test-create-nuget-package.yml/badge.svg)](https://github.com/agdevx/AGDevX.NET/actions/workflows/build-test-create-nuget-package.yml)
+[![NuGet](https://img.shields.io/nuget/v/AGDevX.svg)](https://www.nuget.org/packages/AGDevX)
+
 AGDevX .NET is a collection of C# extension methods, utilities, and other helpful, foundational code that can help make developing applications more elegant.
 
 # Features

--- a/docs/plans/2026-03-01-quality-tooling-improvements-design.md
+++ b/docs/plans/2026-03-01-quality-tooling-improvements-design.md
@@ -1,0 +1,110 @@
+# Quality & Tooling Improvements Design
+
+**Date:** 2026-03-01
+**Status:** Approved
+**Branch:** Single branch with logical commits
+
+## Goal
+
+Close testing gaps, improve API design, complete XML documentation, add build tooling, and enhance CI — all in one cohesive effort.
+
+## Decisions
+
+- **Dependency policy updated:** "Zero runtime dependencies" replaces "zero external dependencies." Build-time tooling (`PrivateAssets="All"`) is acceptable.
+- **IReadOnlyList scope:** Both Get and TryGet variants change for consistency.
+- **Coverage threshold:** 80% line coverage, enforced in CI.
+- **NuGet publishing:** Excluded from this effort (separate task).
+
+---
+
+## 1. Testing Gaps
+
+### CodedArgumentNullExceptionTests.cs
+
+New test file with 5 `[Fact]` tests (one per constructor overload), matching the pattern of all other exception test files. Nested `When_constructing` class with `//-- Arrange`, `//-- Act`, `//-- Assert` comments.
+
+### Enum String Value Tests
+
+New files in `AGDevX.Tests/Security/`:
+- `Auth0ClaimTypeTests.cs`
+- `CustomClaimTypeTests.cs`
+- `JwtClaimTypeTests.cs`
+
+Each uses `[Theory]/[InlineData]` to assert every enum's `.StringValue()` matches the expected spec string (e.g., `JwtClaimType.Subject` → `"sub"`).
+
+### GetExceptionDetail for Plain Exception
+
+Add test in `ExceptionDetailTests.cs` that directly calls `exception.GetExceptionDetail("CODE")` on a regular `Exception` (not `CodedApplicationException`).
+
+---
+
+## 2. API: IReadOnlyList Return Types
+
+Change public return types on 6 methods:
+- `GetAudiences` / `TryGetAudiences`: `List<string>` → `IReadOnlyList<string>`
+- `GetScopes` / `TryGetScopes`: `List<string>` → `IReadOnlyList<string>`
+- `GetRoles` / `TryGetRoles`: `List<string>` → `IReadOnlyList<string>`
+
+Private `GetClaimValues<T>` keeps returning `List<T>` internally (`List<T>` implements `IReadOnlyList<T>`). Update test assertions accordingly.
+
+Breaking change — acceptable in alpha.
+
+---
+
+## 3. XML Documentation
+
+Add `<summary>` tags to all undocumented public members:
+- 9 exception classes × 5 constructors = 45 constructors
+- `ExceptionDetail`: Code, Message, StackFrames, InnerException properties
+- `ExceptionDetail.StackFrameModel`: LineNumber, Method, Class, AssemblyName, AssemblyFile, CodeFile properties
+- `EnumStringValueAttribute.Value` property
+- `CodedApplicationException.Code` and `CodedArgumentNullException.Code` properties
+
+---
+
+## 4. Build Tooling
+
+### SourceLink
+
+Add `Microsoft.SourceLink.GitHub` to AGDevX.csproj with `PrivateAssets="All"`. Enables NuGet consumers to step into library source during debugging.
+
+### global.json
+
+Pin SDK to 10.0.103 with `"rollForward": "latestPatch"`. Prevents SDK version drift across contributors and CI.
+
+### Directory.Build.props
+
+Extract shared properties from both csprojs:
+- `TargetFrameworks` (net8.0;net10.0)
+- `ImplicitUsings` (disable)
+- `Nullable` (enable)
+
+Each csproj retains only its unique properties.
+
+### PublicApiAnalyzers
+
+Add `Microsoft.CodeAnalysis.PublicApiAnalyzers` to AGDevX.csproj with `PrivateAssets="All"`. Create:
+- `PublicAPI.Shipped.txt` — empty (nothing shipped yet)
+- `PublicAPI.Unshipped.txt` — full current API surface
+
+API moves from Unshipped to Shipped at first GA release.
+
+---
+
+## 5. CI: Code Coverage
+
+Add `--collect:"XPlat Code Coverage"` to the test step. Enforce 80% line coverage threshold — fail the build if below.
+
+---
+
+## 6. README Badges
+
+Add at the top of README.md:
+- GitHub Actions build status badge
+- NuGet version badge (shields.io)
+
+---
+
+## 7. CLAUDE.md Convention Update
+
+Update "Zero external dependencies" section to "Zero runtime dependencies" with a note that build-time tooling is acceptable via `PrivateAssets="All"`.

--- a/docs/plans/2026-03-01-quality-tooling-improvements.md
+++ b/docs/plans/2026-03-01-quality-tooling-improvements.md
@@ -1,0 +1,963 @@
+# Quality & Tooling Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close testing gaps, improve API design (IReadOnlyList), complete XML documentation, add build tooling (SourceLink, global.json, Directory.Build.props, PublicApiAnalyzers), enhance CI (coverage), and add README badges.
+
+**Architecture:** Single branch `ag/quality-tooling-improvements` with logical commits. Tasks are ordered to avoid conflicts: build tooling first, then code changes, then tests, then docs/badges last.
+
+**Tech Stack:** C# / .NET 10 + .NET 8 / xUnit / GitHub Actions
+
+---
+
+## Task 1: Add `Directory.Build.props` and update csprojs
+
+Extract shared properties from both project files into a solution-level `Directory.Build.props`.
+
+**Files:**
+- Create: `Directory.Build.props`
+- Modify: `AGDevX/AGDevX.csproj`
+- Modify: `AGDevX.Tests/AGDevX.Tests.csproj`
+
+**Step 1: Create `Directory.Build.props`**
+
+```xml
+<Project>
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>
+```
+
+**Step 2: Remove extracted properties from `AGDevX/AGDevX.csproj`**
+
+Remove these three lines (they're now in Directory.Build.props):
+```xml
+<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+<ImplicitUsings>disable</ImplicitUsings>
+<Nullable>enable</Nullable>
+```
+
+**Step 3: Remove extracted properties from `AGDevX.Tests/AGDevX.Tests.csproj`**
+
+Remove the same three lines.
+
+**Step 4: Build and run tests**
+
+Run: `dotnet build AGDevX.slnx && dotnet test --verbosity normal`
+Expected: Clean build, all tests pass on both TFMs
+
+**Step 5: Commit**
+
+```
+chore: extract shared properties to Directory.Build.props
+```
+
+---
+
+## Task 2: Add `global.json`
+
+Pin the SDK version to prevent drift across contributors and CI.
+
+**Files:**
+- Create: `global.json`
+
+**Step 1: Create `global.json`**
+
+```json
+{
+  "sdk": {
+    "version": "10.0.103",
+    "rollForward": "latestPatch"
+  }
+}
+```
+
+**Step 2: Build to verify SDK resolves**
+
+Run: `dotnet --version && dotnet build AGDevX.slnx`
+Expected: SDK 10.0.103 (or later patch), clean build
+
+**Step 3: Commit**
+
+```
+chore: add global.json to pin SDK version
+```
+
+---
+
+## Task 3: Add SourceLink
+
+Enable source debugging for NuGet consumers.
+
+**Files:**
+- Modify: `AGDevX/AGDevX.csproj`
+
+**Step 1: Add SourceLink package reference to `AGDevX/AGDevX.csproj`**
+
+Add to the existing `<ItemGroup>` (or create a new one above the `None Include` items):
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+</ItemGroup>
+```
+
+**Step 2: Build to verify**
+
+Run: `dotnet build AGDevX.slnx -c Release`
+Expected: Clean build
+
+**Step 3: Commit**
+
+```
+chore: add SourceLink for NuGet source debugging
+```
+
+---
+
+## Task 4: Add PublicApiAnalyzers
+
+Track public API surface to prevent accidental breaking changes.
+
+**Files:**
+- Modify: `AGDevX/AGDevX.csproj`
+- Create: `AGDevX/PublicAPI.Shipped.txt`
+- Create: `AGDevX/PublicAPI.Unshipped.txt`
+
+**Step 1: Add PublicApiAnalyzers package reference to `AGDevX/AGDevX.csproj`**
+
+Add to the same `<ItemGroup>` as SourceLink:
+```xml
+<PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
+```
+
+**Step 2: Create empty `PublicAPI.Shipped.txt`**
+
+```
+#nullable enable
+```
+
+(Just the nullable directive — nothing shipped yet.)
+
+**Step 3: Build to get the full list of unshipped API diagnostics**
+
+Run: `dotnet build AGDevX/AGDevX.csproj -c Release 2>&1`
+
+The build will produce RS0016 warnings for every public symbol. Collect these.
+
+**Step 4: Create `PublicAPI.Unshipped.txt` with all current public API**
+
+Populate from the RS0016 warnings. The file should contain every public type, method, property, constructor, and enum member. Format example:
+```
+#nullable enable
+AGDevX.Assemblies.AssemblyExtensions
+static AGDevX.Assemblies.AssemblyExtensions.FullNameStartsWithPrefix(this System.Reflection.Assembly! assembly, string? prefix) -> bool
+...
+```
+
+**Step 5: Build to verify no RS0016 warnings remain**
+
+Run: `dotnet build AGDevX/AGDevX.csproj -c Release`
+Expected: Clean build
+
+**Step 6: Commit**
+
+```
+chore: add PublicApiAnalyzers to track public API surface
+```
+
+---
+
+## Task 5: Update CLAUDE.md dependency convention
+
+**Files:**
+- Modify: `.claude/CLAUDE.md`
+
+**Step 1: Update the "Zero external dependencies" section**
+
+Change:
+```markdown
+### Zero external dependencies
+- This library depends only on the .NET runtime — no NuGet packages
+- Keep it that way unless there's a compelling reason to add one
+```
+
+To:
+```markdown
+### Zero runtime dependencies
+- This library has no runtime NuGet dependencies — consumers get no transitive packages
+- Build-time tooling (SourceLink, analyzers) is acceptable via `PrivateAssets="All"`
+- Keep runtime dependencies at zero unless there's a compelling reason to add one
+```
+
+**Step 2: Commit**
+
+```
+docs: update dependency convention to distinguish runtime from build-time
+```
+
+---
+
+## Task 6: Change collection return types to `IReadOnlyList<string>`
+
+**Files:**
+- Modify: `AGDevX/Security/ClaimsPrincipalExtensions.cs:67,76,776,785,819,828`
+
+**Step 1: Update `GetAudiences` return type (line 67)**
+
+Change:
+```csharp
+    public static List<string> GetAudiences(this ClaimsPrincipal claimsPrincipal)
+```
+To:
+```csharp
+    public static IReadOnlyList<string> GetAudiences(this ClaimsPrincipal claimsPrincipal)
+```
+
+**Step 2: Update `TryGetAudiences` return type (line 76)**
+
+Change:
+```csharp
+    public static List<string>? TryGetAudiences(this ClaimsPrincipal claimsPrincipal)
+```
+To:
+```csharp
+    public static IReadOnlyList<string>? TryGetAudiences(this ClaimsPrincipal claimsPrincipal)
+```
+
+**Step 3: Update `GetScopes` return type (line 776)**
+
+Change:
+```csharp
+    public static List<string> GetScopes(this ClaimsPrincipal claimsPrincipal)
+```
+To:
+```csharp
+    public static IReadOnlyList<string> GetScopes(this ClaimsPrincipal claimsPrincipal)
+```
+
+**Step 4: Update `TryGetScopes` return type (line 785)**
+
+Change:
+```csharp
+    public static List<string>? TryGetScopes(this ClaimsPrincipal claimsPrincipal)
+```
+To:
+```csharp
+    public static IReadOnlyList<string>? TryGetScopes(this ClaimsPrincipal claimsPrincipal)
+```
+
+Also update the implementation to return an array (since `.ToList()` returns `List<T>` which implements `IReadOnlyList<T>`, this actually already works — but for Scopes and Roles, the `.Split(' ').ToList()` can stay as-is since `List<T>` implements `IReadOnlyList<T>`).
+
+**Step 5: Update `GetRoles` return type (line 819)**
+
+Change:
+```csharp
+    public static List<string> GetRoles(this ClaimsPrincipal claimsPrincipal)
+```
+To:
+```csharp
+    public static IReadOnlyList<string> GetRoles(this ClaimsPrincipal claimsPrincipal)
+```
+
+**Step 6: Update `TryGetRoles` return type (line 828)**
+
+Change:
+```csharp
+    public static List<string>? TryGetRoles(this ClaimsPrincipal claimsPrincipal)
+```
+To:
+```csharp
+    public static IReadOnlyList<string>? TryGetRoles(this ClaimsPrincipal claimsPrincipal)
+```
+
+**Step 7: Update XML docs for these 6 methods**
+
+Change `as a list` to `as a read-only list` in all 6 XML doc summaries.
+
+**Step 8: Add `using System.Collections.Generic;` if not already present**
+
+Check the using statements at the top of the file — it's already there.
+
+**Step 9: Update test assertions**
+
+In `ClaimsPrincipalExtensionsGetTests.cs` and `ClaimsPrincipalExtensionsTryGetTests.cs`, the `.Count` property is available on `IReadOnlyList<T>` so assertions like `Assert.Equal(2, result.Count)` will still compile. No test changes needed.
+
+**Step 10: Build and run tests**
+
+Run: `dotnet build AGDevX.slnx && dotnet test --verbosity normal`
+Expected: Clean build, all tests pass
+
+**Step 11: Commit**
+
+```
+feat: return IReadOnlyList<string> from collection claim methods
+
+GetAudiences, GetScopes, GetRoles and their TryGet variants now return
+IReadOnlyList<string> instead of List<string>. Breaking change acceptable
+in alpha — prevents consumers from mutating returned collections.
+```
+
+---
+
+## Task 7: Add `CodedArgumentNullExceptionTests.cs`
+
+**Files:**
+- Create: `AGDevX.Tests/Exceptions/CodedArgumentNullExceptionTests.cs`
+
+**Step 1: Write the test file**
+
+Follow the exact pattern from `CodedApplicationExceptionTests.cs`, but adapted for `CodedArgumentNullException` (which takes `argumentName` instead of `message` in its first string parameter):
+
+```csharp
+using System;
+using AGDevX.Exceptions;
+using Xunit;
+
+namespace AGDevX.Tests.Exceptions;
+
+public sealed class CodedArgumentNullExceptionTests
+{
+    public class When_throwing_a_CodedArgumentNullException
+    {
+        [Fact]
+        public void And_has_correct_default_code_then_assert_true()
+        {
+            //-- Arrange
+            var defaultCode = "CODED_ARGUMENT_NULL_EXCEPTION";
+
+            //-- Assert
+            Assert.Equal(defaultCode, new CodedArgumentNullException().Code);
+        }
+
+        [Fact]
+        public void And_has_correct_code_then_assert_true()
+        {
+            //-- Arrange
+            var code = "ex";
+
+            //-- Assert
+            Assert.Equal(code, new CodedArgumentNullException("arg", code).Code);
+        }
+
+        [Fact]
+        public void And_has_correct_argument_name_then_assert_true()
+        {
+            //-- Arrange
+            var argumentName = "testArgument";
+
+            //-- Assert
+            Assert.Equal(argumentName, new CodedArgumentNullException(argumentName).ParamName);
+        }
+
+        [Fact]
+        public void And_should_have_inner_exception_then_make_sure_it_has_inner_exception()
+        {
+            //-- Arrange
+            var message = "Test message";
+            var innerExceptionMessage = "Inner exception message";
+            var innerException = new Exception(innerExceptionMessage);
+
+            //-- Assert
+            Assert.Equal(message, new CodedArgumentNullException(message, innerException).Message);
+            Assert.Same(innerException, new CodedArgumentNullException(message, innerException).InnerException);
+        }
+
+        [Fact]
+        public void And_should_have_inner_exception_then_make_all_properties_are_correct()
+        {
+            //-- Arrange
+            var argumentName = "testArgument";
+            var code = "ex";
+            var innerExceptionMessage = "Inner exception message";
+            var innerException = new Exception(innerExceptionMessage);
+
+            //-- Assert
+            Assert.Equal(argumentName, new CodedArgumentNullException(argumentName, code, innerException).ParamName);
+            Assert.Equal(code, new CodedArgumentNullException(argumentName, code, innerException).Code);
+            Assert.Same(innerException, new CodedArgumentNullException(argumentName, code, innerException).InnerException);
+        }
+    }
+}
+```
+
+Note: `CodedArgumentNullException` inherits from `ArgumentNullException`, so the first string parameter is `argumentName` (accessible via `.ParamName`), not `message`. The `.Message` property prepends "Value cannot be null." to the parameter name. The 2-string-arg constructor is `(argumentName, code)`, not `(message, code)`.
+
+**Step 2: Run tests**
+
+Run: `dotnet test AGDevX.Tests --filter "FullyQualifiedName~CodedArgumentNullExceptionTests" --verbosity normal`
+Expected: 5 tests pass
+
+**Step 3: Commit**
+
+```
+test: add CodedArgumentNullException unit tests
+```
+
+---
+
+## Task 8: Add enum string value tests
+
+**Files:**
+- Create: `AGDevX.Tests/Security/Auth0ClaimTypeTests.cs`
+- Create: `AGDevX.Tests/Security/CustomClaimTypeTests.cs`
+- Create: `AGDevX.Tests/Security/JwtClaimTypeTests.cs`
+
+**Step 1: Create `Auth0ClaimTypeTests.cs`**
+
+```csharp
+using AGDevX.Enums;
+using AGDevX.Security;
+using Xunit;
+
+namespace AGDevX.Tests.Security;
+
+public sealed class Auth0ClaimTypeTests
+{
+    public class When_calling_StringValue
+    {
+        [Theory]
+        [InlineData(Auth0ClaimType.GrantType, "gty")]
+        public void Then_return_expected_string_value(Auth0ClaimType claimType, string expected)
+        {
+            //-- Act
+            var result = claimType.StringValue();
+
+            //-- Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}
+```
+
+**Step 2: Create `CustomClaimTypeTests.cs`**
+
+```csharp
+using AGDevX.Enums;
+using AGDevX.Security;
+using Xunit;
+
+namespace AGDevX.Tests.Security;
+
+public sealed class CustomClaimTypeTests
+{
+    public class When_calling_StringValue
+    {
+        [Theory]
+        [InlineData(CustomClaimType.RequestIp, "request_ip")]
+        [InlineData(CustomClaimType.AppMetadata, "app_metadata")]
+        [InlineData(CustomClaimType.CreatedAt, "created_at")]
+        [InlineData(CustomClaimType.UserId, "user_id")]
+        [InlineData(CustomClaimType.IsActive, "isActive")]
+        public void Then_return_expected_string_value(CustomClaimType claimType, string expected)
+        {
+            //-- Act
+            var result = claimType.StringValue();
+
+            //-- Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}
+```
+
+**Step 3: Create `JwtClaimTypeTests.cs`**
+
+```csharp
+using AGDevX.Enums;
+using AGDevX.Security;
+using Xunit;
+
+namespace AGDevX.Tests.Security;
+
+public sealed class JwtClaimTypeTests
+{
+    public class When_calling_StringValue
+    {
+        [Theory]
+        [InlineData(JwtClaimType.Issuer, "iss")]
+        [InlineData(JwtClaimType.Subject, "sub")]
+        [InlineData(JwtClaimType.Audience, "aud")]
+        [InlineData(JwtClaimType.Expiration, "exp")]
+        [InlineData(JwtClaimType.NotBefore, "nbf")]
+        [InlineData(JwtClaimType.IssuedAt, "iat")]
+        [InlineData(JwtClaimType.JwtId, "jti")]
+        [InlineData(JwtClaimType.Name, "name")]
+        [InlineData(JwtClaimType.GivenName, "given_name")]
+        [InlineData(JwtClaimType.FamilyName, "family_name")]
+        [InlineData(JwtClaimType.MiddleName, "middle_name")]
+        [InlineData(JwtClaimType.Nickname, "nickname")]
+        [InlineData(JwtClaimType.PreferredUsername, "preferred_username")]
+        [InlineData(JwtClaimType.Profile, "profile")]
+        [InlineData(JwtClaimType.Picture, "picture")]
+        [InlineData(JwtClaimType.Website, "website")]
+        [InlineData(JwtClaimType.Email, "email")]
+        [InlineData(JwtClaimType.EmailVerified, "email_verified")]
+        [InlineData(JwtClaimType.Gender, "gender")]
+        [InlineData(JwtClaimType.Birthdate, "birthdate")]
+        [InlineData(JwtClaimType.ZoneInfo, "zoneinfo")]
+        [InlineData(JwtClaimType.Locale, "locale")]
+        [InlineData(JwtClaimType.PhoneNumber, "phone_number")]
+        [InlineData(JwtClaimType.PhoneNumberVerified, "phone_number_verified")]
+        [InlineData(JwtClaimType.Address, "address")]
+        [InlineData(JwtClaimType.UpdatedAt, "updated_at")]
+        [InlineData(JwtClaimType.AuthorizedParty, "azp")]
+        [InlineData(JwtClaimType.Nonce, "nonce")]
+        [InlineData(JwtClaimType.AuthTime, "auth_time")]
+        [InlineData(JwtClaimType.AccessTokenHash, "at_hash")]
+        [InlineData(JwtClaimType.CodeHash, "c_hash")]
+        [InlineData(JwtClaimType.AuthenticationContextClassReference, "acr")]
+        [InlineData(JwtClaimType.AuthenticationMethodsReference, "amr")]
+        [InlineData(JwtClaimType.SessionId, "sid")]
+        [InlineData(JwtClaimType.Scope, "scope")]
+        [InlineData(JwtClaimType.ClientId, "client_id")]
+        [InlineData(JwtClaimType.Roles, "roles")]
+        public void Then_return_expected_string_value(JwtClaimType claimType, string expected)
+        {
+            //-- Act
+            var result = claimType.StringValue();
+
+            //-- Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `dotnet test AGDevX.Tests --filter "FullyQualifiedName~ClaimTypeTests" --verbosity normal`
+Expected: 43 tests pass (1 + 5 + 37)
+
+**Step 5: Commit**
+
+```
+test: add dedicated enum string value tests for claim types
+```
+
+---
+
+## Task 9: Add `GetExceptionDetail` test for plain `Exception` overload
+
+**Files:**
+- Modify: `AGDevX.Tests/Exceptions/ExceptionDetailTests.cs`
+
+**Step 1: Add a new nested test class for the plain Exception overload**
+
+Add inside `When_calling_GetExceptionDetail`:
+
+```csharp
+public class And_called_on_a_plain_Exception
+{
+    [Fact]
+    public void Then_return_exception_detail_with_provided_code()
+    {
+        //-- Arrange
+        var code = "CUSTOM_CODE";
+        var message = "Something went wrong";
+        var exception = new InvalidOperationException(message);
+
+        //-- Act
+        ExceptionDetail exceptionDetail;
+        try
+        {
+            throw exception;
+        }
+        catch (Exception ex)
+        {
+            exceptionDetail = ex.GetExceptionDetail(code);
+        }
+
+        //-- Assert
+        Assert.Equal(code, exceptionDetail.Code);
+        Assert.Equal(message, exceptionDetail.Message);
+        Assert.NotNull(exceptionDetail.StackFrames);
+        Assert.Null(exceptionDetail.InnerException);
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `dotnet test AGDevX.Tests --filter "FullyQualifiedName~ExceptionDetailTests" --verbosity normal`
+Expected: 5 tests pass (4 existing + 1 new)
+
+**Step 3: Commit**
+
+```
+test: add GetExceptionDetail test for plain Exception overload
+```
+
+---
+
+## Task 10: Add XML docs to all undocumented public members
+
+**Files:**
+- Modify: `AGDevX/Exceptions/CodedApplicationException.cs`
+- Modify: `AGDevX/Exceptions/CodedArgumentNullException.cs`
+- Modify: `AGDevX/Exceptions/AcquireTokenException.cs`
+- Modify: `AGDevX/Exceptions/ApplicationStartupException.cs`
+- Modify: `AGDevX/Exceptions/ClaimNotFoundException.cs`
+- Modify: `AGDevX/Exceptions/ExtensionMethodException.cs`
+- Modify: `AGDevX/Exceptions/ExtensionMethodParameterNullException.cs`
+- Modify: `AGDevX/Exceptions/MissingRequiredClaimException.cs`
+- Modify: `AGDevX/Exceptions/NotAuthorizedException.cs`
+- Modify: `AGDevX/Exceptions/ExceptionDetail.cs`
+- Modify: `AGDevX/Enums/EnumStringValueAttribute.cs`
+
+**Step 1: Add constructor XML docs to `CodedApplicationException.cs`**
+
+For the base classes (`CodedApplicationException` and `CodedArgumentNullException`), use these patterns:
+
+```csharp
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedApplicationException"/> class with the default code.
+/// </summary>
+public CodedApplicationException()
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message.
+/// </summary>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+public CodedApplicationException(string message)
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message and code.
+/// </summary>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+/// <param name="code">A code providing additional context into the origin of the exception.</param>
+public CodedApplicationException(string message, string code)
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message and inner exception.
+/// </summary>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+/// <param name="innerException">The exception that is the cause of the current exception.</param>
+public CodedApplicationException(string message, Exception innerException)
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedApplicationException"/> class with a specified error message, code, and inner exception.
+/// </summary>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+/// <param name="code">A code providing additional context into the origin of the exception.</param>
+/// <param name="innerException">The exception that is the cause of the current exception.</param>
+public CodedApplicationException(string message, string code, Exception innerException)
+```
+
+Also add to the `Code` property:
+```csharp
+/// <summary>
+/// A code providing additional context into the origin of the exception.
+/// </summary>
+public virtual string Code { get; set; } = "CODED_APPLICATION_EXCEPTION";
+```
+
+**Step 2: Add constructor XML docs to `CodedArgumentNullException.cs`**
+
+Same pattern but adapted for `argumentName` parameter:
+
+```csharp
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with the default code.
+/// </summary>
+public CodedArgumentNullException()
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified argument name.
+/// </summary>
+/// <param name="argumentName">The name of the argument that caused the exception.</param>
+public CodedArgumentNullException(string argumentName)
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified argument name and code.
+/// </summary>
+/// <param name="argumentName">The name of the argument that caused the exception.</param>
+/// <param name="code">A code providing additional context into the origin of the exception.</param>
+public CodedArgumentNullException(string argumentName, string code)
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified message and inner exception.
+/// </summary>
+/// <param name="message">The error message that explains the reason for the exception.</param>
+/// <param name="innerException">The exception that is the cause of the current exception.</param>
+public CodedArgumentNullException(string message, Exception innerException)
+
+/// <summary>
+/// Initializes a new instance of the <see cref="CodedArgumentNullException"/> class with a specified argument name, code, and inner exception.
+/// </summary>
+/// <param name="argumentName">The name of the argument that caused the exception.</param>
+/// <param name="code">A code providing additional context into the origin of the exception.</param>
+/// <param name="innerException">The exception that is the cause of the current exception.</param>
+public CodedArgumentNullException(string argumentName, string code, Exception innerException)
+```
+
+Also add to the `Code` property:
+```csharp
+/// <summary>
+/// A code providing additional context into the origin of the exception.
+/// </summary>
+```
+
+**Step 3: Add constructor XML docs to all 7 derived exception classes**
+
+For each derived exception (`AcquireTokenException`, `ApplicationStartupException`, `ClaimNotFoundException`, `ExtensionMethodException`, `ExtensionMethodParameterNullException`, `MissingRequiredClaimException`, `NotAuthorizedException`), follow the same 5-constructor pattern using `<see cref="ClassName"/>` and the class's appropriate parameter names (e.g., `ExtensionMethodParameterNullException` uses `argumentName` since it inherits from `CodedArgumentNullException`).
+
+**Step 4: Add XML docs to `ExceptionDetail` properties**
+
+```csharp
+/// <summary>
+/// A code identifying the type or origin of the exception.
+/// </summary>
+public required string Code { get; set; }
+
+/// <summary>
+/// The exception error message.
+/// </summary>
+public required string Message { get; set; }
+
+/// <summary>
+/// The parsed stack frames from the exception, or <see langword="null"/> if stack frames were not included.
+/// </summary>
+public IEnumerable<StackFrameModel>? StackFrames { get; set; }
+
+/// <summary>
+/// The inner exception detail, or <see langword="null"/> if there is no inner exception.
+/// </summary>
+public ExceptionDetail? InnerException { get; set; }
+```
+
+**Step 5: Add XML docs to `StackFrameModel` properties**
+
+```csharp
+/// <summary>
+/// Structured representation of a single stack frame.
+/// </summary>
+public sealed class StackFrameModel
+{
+    /// <summary>
+    /// The line number in the source code file where the frame originated.
+    /// </summary>
+    public int LineNumber { get; set; }
+
+    /// <summary>
+    /// The method signature where the frame originated.
+    /// </summary>
+    public string? Method { get; set; }
+
+    /// <summary>
+    /// The fully qualified class name where the frame originated.
+    /// </summary>
+    public string? Class { get; set; }
+
+    /// <summary>
+    /// The full name of the assembly containing the frame.
+    /// </summary>
+    public string? AssemblyName { get; set; }
+
+    /// <summary>
+    /// The file path of the assembly containing the frame.
+    /// </summary>
+    public string? AssemblyFile { get; set; }
+
+    /// <summary>
+    /// The source code file path where the frame originated.
+    /// </summary>
+    public string? CodeFile { get; set; }
+}
+```
+
+**Step 6: Add XML doc to `EnumStringValueAttribute.Value`**
+
+In `AGDevX/Enums/EnumStringValueAttribute.cs`, add before the `Value` property:
+
+```csharp
+/// <summary>
+/// The string value associated with the decorated enum field.
+/// </summary>
+public string Value { get; }
+```
+
+**Step 7: Build to verify no XML doc warnings**
+
+Run: `dotnet build AGDevX.slnx`
+Expected: Clean build
+
+**Step 8: Commit**
+
+```
+docs: add XML documentation to all undocumented public members
+
+Covers exception constructors, ExceptionDetail/StackFrameModel properties,
+CodedApplicationException.Code, CodedArgumentNullException.Code, and
+EnumStringValueAttribute.Value.
+```
+
+---
+
+## Task 11: Add code coverage to CI
+
+**Files:**
+- Modify: `.github/workflows/build-test-create-nuget-package.yml`
+
+**Step 1: Update the test step to collect coverage**
+
+Change:
+```yaml
+      - name: Run Unit Tests
+        run: dotnet test --no-build --verbosity normal
+```
+
+To:
+```yaml
+      - name: Run Unit Tests
+        run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Check Code Coverage Threshold
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          # Find the coverage file (Cobertura XML)
+          COVERAGE_FILE=$(find ./coverage -name "coverage.cobertura.xml" | head -1)
+          if [ -z "$COVERAGE_FILE" ]; then
+            echo "::error::No coverage file found"
+            exit 1
+          fi
+          # Extract line coverage rate from Cobertura XML
+          LINE_RATE=$(grep -oP 'line-rate="\K[^"]+' "$COVERAGE_FILE" | head -1)
+          COVERAGE_PCT=$(echo "$LINE_RATE * 100" | bc -l | xargs printf "%.1f")
+          echo "Line coverage: ${COVERAGE_PCT}%"
+          THRESHOLD=80
+          if (( $(echo "$COVERAGE_PCT < $THRESHOLD" | bc -l) )); then
+            echo "::error::Code coverage ${COVERAGE_PCT}% is below ${THRESHOLD}% threshold"
+            exit 1
+          fi
+          echo "Coverage ${COVERAGE_PCT}% meets ${THRESHOLD}% threshold"
+```
+
+Note: Coverage threshold check runs only on ubuntu-latest to avoid running it 3x and dealing with Windows/macOS shell differences.
+
+**Step 2: Commit**
+
+```
+ci: add code coverage collection and 80% threshold enforcement
+```
+
+---
+
+## Task 12: Add README badges
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add badges at the top of the README**
+
+Add immediately after `# AGDevX .NET` (line 1):
+
+```markdown
+# AGDevX .NET
+
+[![Build](https://github.com/agdevx/AGDevX.NET/actions/workflows/build-test-create-nuget-package.yml/badge.svg)](https://github.com/agdevx/AGDevX.NET/actions/workflows/build-test-create-nuget-package.yml)
+[![NuGet](https://img.shields.io/nuget/v/AGDevX.svg)](https://www.nuget.org/packages/AGDevX)
+```
+
+**Step 2: Commit**
+
+```
+docs: add build status and NuGet version badges to README
+```
+
+---
+
+## Task 13: Update `PublicAPI.Unshipped.txt` with IReadOnlyList changes
+
+After the IReadOnlyList changes in Task 6, the public API file will be stale.
+
+**Files:**
+- Modify: `AGDevX/PublicAPI.Unshipped.txt`
+
+**Step 1: Build and check for RS0016/RS0017 warnings**
+
+Run: `dotnet build AGDevX/AGDevX.csproj -c Release 2>&1`
+
+**Step 2: Update `PublicAPI.Unshipped.txt`**
+
+Remove old `List<string>` signatures, add new `IReadOnlyList<string>` signatures.
+
+**Step 3: Build to verify clean**
+
+Run: `dotnet build AGDevX/AGDevX.csproj -c Release`
+Expected: Clean build
+
+**Step 4: Commit**
+
+```
+chore: update PublicAPI.Unshipped.txt for IReadOnlyList changes
+```
+
+---
+
+## Task 14: Final verification
+
+**Step 1: Run full build and test suite**
+
+Run: `dotnet build AGDevX.slnx -c Release && dotnet test --verbosity normal`
+Expected: Clean build, all tests pass on both net8.0 and net10.0
+
+**Step 2: Verify no remaining warnings**
+
+Run: `dotnet build AGDevX.slnx -c Release -warnaserror 2>&1`
+Check for any remaining warnings.
+
+**Step 3: Push and create PR**
+
+```bash
+git push -u origin ag/quality-tooling-improvements
+gh pr create --title "Quality and tooling improvements" --body "$(cat <<'EOF'
+## Summary
+- Add Directory.Build.props for shared project properties
+- Add global.json to pin SDK version
+- Add SourceLink for NuGet source debugging
+- Add PublicApiAnalyzers to track public API surface
+- Return IReadOnlyList<string> from collection claim methods (breaking, alpha)
+- Add CodedArgumentNullExceptionTests
+- Add dedicated enum string value tests for Auth0/Custom/JWT claim types
+- Add GetExceptionDetail test for plain Exception overload
+- Add XML docs to all undocumented public members (constructors, properties)
+- Add code coverage collection and 80% threshold in CI
+- Add build status and NuGet version badges to README
+- Update CLAUDE.md dependency convention
+
+## Test plan
+- [ ] All existing tests pass on net8.0 and net10.0
+- [ ] New CodedArgumentNullException tests pass (5 tests)
+- [ ] New enum string value tests pass (43 tests)
+- [ ] New ExceptionDetail plain Exception test passes
+- [ ] IReadOnlyList return types compile and tests pass
+- [ ] PublicApiAnalyzers produces clean build
+- [ ] CI workflow runs successfully
+EOF
+)"
+```
+
+---
+
+## Execution Order
+
+Tasks 1-5 are build tooling/config (independent of code changes).
+Task 6 is the API change.
+Tasks 7-9 are new tests (independent of each other).
+Task 10 is XML docs (independent).
+Task 11-12 are CI/README (independent).
+Task 13 depends on Tasks 4 + 6 (PublicAPI update).
+Task 14 is final verification.
+
+**Parallelizable groups:**
+- Wave 1: Tasks 1, 2, 3, 5 (config/tooling, independent files)
+- Wave 2: Task 4 (PublicApiAnalyzers — needs csproj from Task 3)
+- Wave 3: Tasks 6, 7, 8, 9, 10, 11, 12 (code changes, all touch different files)
+- Wave 4: Task 13 (PublicAPI update after Task 6)
+- Wave 5: Task 14 (final verification)

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.103",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Summary
- **Build tooling:** Add Directory.Build.props, global.json (SDK 10.0.103), SourceLink, PublicApiAnalyzers
- **API improvement:** Return `IReadOnlyList<string>` from `GetAudiences`/`GetScopes`/`GetRoles` and TryGet variants (breaking, alpha)
- **Bug fix:** `CodedArgumentNullException` 3-arg constructor now correctly preserves `ParamName`
- **Testing:** Add `CodedArgumentNullExceptionTests`, enum string value tests (43 cases), `GetExceptionDetail` plain Exception test
- **XML docs:** Document all previously undocumented public members (75 members: constructors, properties, nested types)
- **CI:** Add code coverage collection with 80% line threshold enforcement
- **README:** Add build status and NuGet version badges
- **Convention:** Update dependency policy from "zero external" to "zero runtime" (build-time tooling allowed)

## Test plan
- [x] All 409 tests pass on net8.0 and net10.0
- [x] 5 new CodedArgumentNullException tests pass
- [x] 43 new enum string value tests pass
- [x] 1 new ExceptionDetail plain Exception test passes
- [x] IReadOnlyList return types compile and existing tests pass
- [x] PublicApiAnalyzers produces clean build (no RS0016 warnings)
- [x] Build: 0 errors, 50 warnings (all pre-existing)
- [ ] CI workflow runs successfully with coverage collection